### PR TITLE
Naming consistency

### DIFF
--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -160,7 +160,7 @@ link:$$https://www.linkedin.com/in/rene-pickhardt-80313744/$$[]
 Rene would also like to thank all of the patrons who support his work through monthly donations. You can support Rene on Patreon at
 link:$$https://patreon.com/renepickhardt$$[].
 
-Or you can support his work directly with bitcoin (also via the Lightning network) at link:$$https://tallyco.in/s/lnbook$$[] for which Rene is equally thankful as for his patreons.
+Or you can support his work directly with bitcoin (also via the Lightning Network) at link:$$https://tallyco.in/s/lnbook$$[] for which Rene is equally thankful as for his patreons.
 
 
 [[acknowledgments_sec]]
@@ -172,7 +172,7 @@ Thank you all for supporting me throughout this journey.
 
 === Acknowledgments by Rene
 
-I want to mainly thank all the students I ever tought and who engaged into interesting discussions and questions. Believe it or not from you I learnt the most. I am also gratefull to the Bitcoin and Lightning Network community who wellcomed me and supported my efforts. In particular I am grateful to all the open source bitcoin and lightning network protocol developers and people who fund them to make that technology possible. Last but not least I am thankfull to my loved ones.
+I want to mainly thank all the students I ever tought and who engaged into interesting discussions and questions. Believe it or not from you I learnt the most. I am also gratefull to the Bitcoin and Lightning Network community who wellcomed me and supported my efforts. In particular I am grateful to all the open source Bitcoin and Lightning Network protocol developers and people who fund them to make that technology possible. Last but not least I am thankfull to my loved ones.
 
 [[github_contrib]]
 === Contributions


### PR DESCRIPTION
Fixed the casing of Bitcoin (the protocol vs bitcoin the token) and the Lightning Network, to make it consistent with @aantonop sections