### PR TITLE
Update ch01.asciidoc

### DIFF
--- a/ch01.asciidoc
+++ b/ch01.asciidoc
@@ -83,7 +83,7 @@ gamer::
 Similar to the content creator, a gamer and live streamer would like to be tipped.
 However, in gaming (and gambling) the transfer of bitcoin could be part of the game for example to trade items or to wage for bets.
 
-refugee::
+economic migrant::
 Remittance is an important way for refugees to help their loved one in their home country.
 Characteristic for remittance is that the payments usually are cross border and relatively small.
 However, they might happen on a monthly base as they are just a fraction of the monthly wage.

--- a/ch01.asciidoc
+++ b/ch01.asciidoc
@@ -83,7 +83,7 @@ gamer::
 Similar to the content creator, a gamer and live streamer would like to be tipped.
 However, in gaming (and gambling) the transfer of bitcoin could be part of the game for example to trade items or to wage for bets.
 
-economic migrant::
+migrant::
 Remittance is an important way for refugees to help their loved one in their home country.
 Characteristic for remittance is that the payments usually are cross border and relatively small.
 However, they might happen on a monthly base as they are just a fraction of the monthly wage.


### PR DESCRIPTION
I'm proposing to change the word refugee to economic migrant.   Refugee suggests that someone has had to leave their own country without a choice, where-as I think most people submitting remittances have left their country  by their own choice. 

I think economic migrant is a step towards the right wording, but could also carry other unwanted connotations.  Maybe "remittance sender" would be more accurate and less controversial...