### PR TITLE
`all Bitcoin` -> `all bitcoins`

### DIFF
--- a/ch01.asciidoc
+++ b/ch01.asciidoc
@@ -40,7 +40,7 @@ Effectively the most recent update of the payment channel (encoded as a bitcoin 
 In July of 2011, on the bitcointalk.org forum,  a pseudonomous user by the name of _hashcoin_ proposed the usage of Timelocks via the `nLockTime` function of the bitcoin network to solve the custody problem of exchanges.footnote:[Hashcoin on Bitcoin talk on July 4th 2011 - Instant TX for established business relationships (need replacements/nLockTime) http://web.archive.org/web/20190419103503/https://bitcointalk.org/index.php?topic=25786.0]
 The idea was to be able to quickly trade / sell Bitcoin without the necessity to send all the bitcoins to the exchange in the first place.
 Hashcoin effectively proposed what we would call an unidirectional payment channel today.
-With this mechanism a user A could fund a multisig wallet between A and another user B together with a timelocked transaction sending all Bitcoin Back to A.
+With this mechanism a user A could fund a multisig wallet between A and another user B together with a timelocked transaction sending all bitcoins Back to A.
 The funding tx would not be signed and broadcasted by A before B provided a signature for the spend.
 Hashcoin imagined user B to be an exchange.
 Whenever user A wanted to send Bitcoin to user B user A could create a newer spend of the funding transaction which would send less Bitcoin back to A and more bitcoin to B.
@@ -54,7 +54,7 @@ This mechanism would allow two users to engage into several smaller transactions
 While this construction of the unidirectional payment channel would have solved the custody problem of exchanges it was nevery widely implemented.
 We can only speculate for reasons and guess that the overhead communication would have had to be standardized - as it is nowadays in the Lightning Network specification - which might have been too much overhead in the early days of Bitcoin.
 Also as a payment channel this system was not too useful as the channel could only at total send the total amount of provided Bitcoin in the funding transaction.
-Once the timelock was over or all Bitcoin were sent to B the channel would have to be closed.
+Once the timelock was over or all bitcoins were sent to B the channel would have to be closed.
 The obvious idea of opening two channels one from A to B and one from B to A would not have helped as each of those channels would have to be closed and reestablished once it ran dry.
 The core breakthrough for the Lightning Network to become a reallity was the ability to create payment channels which technically can live forever and can send money back and forth as often as the peers wish to in combination with routing payments among several channels.
 


### PR DESCRIPTION
I'm pretty sure I've read the correct pluralization and capitalization in the Mastering Bitcoin book a long time ago.