### PR TITLE
travis: Add linter to make sure Unix style line endings are used. Add trailing whitespace linter. Fix typos.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ install:
 script:
   - git grep $'\r' -- "*.asciidoc" "*.md" && echo "^ Possible Windows style line ending detected. Please use Unix style line endings (\n)." && false || true
   - git grep ' $' -- "*.asciidoc" "*.md" && echo "^ Trailing space detected at end of line. Please remove." && false || true
+  - git grep $'\t' -- "*.asciidoc" "*.md" && echo "^ Use of tabs detected. Please use space for indentation." && false || true
   - codespell --ignore-words-list=que $(git ls-files -- "*.asciidoc" "*.md")

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ install:
   - pip3 install --user codespell
 
 script:
+  - git grep $'\r' -- "*.asciidoc" "*.md" && echo "^ Possible Windows style line ending detected. Please use Unix style line endings (\n)." && false || true
   - codespell --ignore-words-list=que $(git ls-files -- "*.asciidoc" "*.md")

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ install:
 
 script:
   - git grep $'\r' -- "*.asciidoc" "*.md" && echo "^ Possible Windows style line ending detected. Please use Unix style line endings (\n)." && false || true
+  - git grep ' $' -- "*.asciidoc" "*.md" && echo "^ Trailing space detected at end of line. Please remove." && false || true
   - codespell --ignore-words-list=que $(git ls-files -- "*.asciidoc" "*.md")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Adjust heading style in each section as follows:
 5. Should include a unique anchor all lower case, underscore separated, within double square brackets (eg. [[intro_to_htlcs]]).
 6. Headings should be followed by a blank line.
 7. Heading should be followed by a paragraph of text, not a lower-level heading without any text. If you find one like this, add a TODO comment (line of 4 slashes "////", line with "TODO: add paragraph", line of 4 slashes)
-8. Often it seems useful to link to a webpage / url. Since the research community figured out that every year about 50% of all outstanding url's become invalid we encourage you to use the wayback machine / Web Archive at: http://web.archive.org and provide a link to a saved copy of the web page. 
+8. Often it seems useful to link to a webpage / url. Since the research community figured out that every year about 50% of all outstanding url's become invalid we encourage you to use the wayback machine / Web Archive at: http://web.archive.org and provide a link to a saved copy of the web page.
 
 Complete Example:
 

--- a/ch01.asciidoc
+++ b/ch01.asciidoc
@@ -25,7 +25,7 @@ We very, very much need such a system, but the way I understand your proposal, i
 ____
 While James A. Donald was probably referring to maintenance of the unspent transaction outputs (UTXOs) database, it quickly became clear that verifying and storing so many transactions would also become infeasible for any blockchain.
 
-A key requirement for a second layer protocol such as Lightning (which will be described in greater depth later in this book) is the ability to sequence transactions external to the blockchain. In the first verisons of Bitcoin, Satoshi Nakamoto recognised this and introduced a data field called `nSequence` into the input transaction data.
+A key requirement for a second layer protocol such as Lightning (which will be described in greater depth later in this book) is the ability to sequence transactions external to the blockchain. In the first versions of Bitcoin, Satoshi Nakamoto recognised this and introduced a data field called `nSequence` into the input transaction data.
 The `nSequence` field was intended to allow users to transmit updated versions of a transaction to the network, changing the outputs of a transaction, effectively creating a payment channel. 
 Such a payment channel would then be valid as long as the transaction was not mined.
 According to a Mailinglist post in 2013 by early Bitcoin developer Mike Hearn, Satoshi Nakamoto envisioned this construction for the use case of high frequency trading.footnote:HearnBitcoinDev[Mike Hearn on Bitcoin-dev - April 16th 2013 - Anti DoS for tx replacement http://web.archive.org/web/20190501234757/https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2013-April/002433.html.]
@@ -34,8 +34,8 @@ There were however some weaknesses in this initial formulation, which limited it
 
 The Revocable Sequence Maturity Contracts (RSMC) which form the payment channels in the first version of the Lightning Network have taken part of their name from their property of fixing the `nSequence` field.
 This is achieved by creating an economic incentive via a penalty mechanism if not the most recent transaction in the payment channel is published to the Bitcoin network.
-Effectively the most recent update of the payment channel (encoded as a bitcoin transaction) becomes enforcable in this way. 
-// find / add sources for some of the claimes
+Effectively the most recent update of the payment channel (encoded as a bitcoin transaction) becomes enforceable in this way.
+// find / add sources for some of the claims
 
 In July of 2011, on the bitcointalk.org forum,  a pseudonomous user by the name of _hashcoin_ proposed the usage of Timelocks via the `nLockTime` function of the bitcoin network to solve the custody problem of exchanges.footnote:[Hashcoin on Bitcoin talk on July 4th 2011 - Instant TX for established business relationships (need replacements/nLockTime) http://web.archive.org/web/20190419103503/https://bitcointalk.org/index.php?topic=25786.0]
 The idea was to be able to quickly trade / sell Bitcoin without the necessity to send all the bitcoins to the exchange in the first place.
@@ -69,7 +69,7 @@ You can watch a video explaining the construction and operation of unidirectiona
 
 Surprisingly both properties took quite some while until the community figured them out.
 Technically speaking the unidirectional payment channel has all the important ingreedients (funding transaction to a 2-2 multisignature wallet, a transaction spending from the wallet encoding the balance, a timelock to allow refunding if the other side becomes unresponsive, off chain communication and the fact that no additional trust other than the one in the bitcoin network) of modern payment channels which are used in the Lightning Network.
-Despite being rather useless in todays world we will study the unidirectional payment channel in more depth in this book as it is an easy to understand educational example to approach the construction of todays payment channels.
+Despite being rather useless in today's world we will study the unidirectional payment channel in more depth in this book as it is an easy to understand educational example to approach the construction of today's payment channels.
 This setup has one safety issue as transactions have been malleable without the segwit upgrade.
 A problem that needed to be solved for any payment channel construction that we know up till today and which has been fixed in August 2017.
 
@@ -91,8 +91,8 @@ Without mentioning the term network or routing of payments the idea of connectin
 In Rosenfelds solution payment providers would be the ultraservers and they would among themselves settle the transactions based on trust.
 It took us another 3 years until the lightning network whitepaper emerged which had solved all the bits and bolts necessary to get rid of the trust in Rosenfelds solution.
 
-It was 2013 that Bitcoin developer Mike Hearn refered to Meni Rosenfelds proposal and suggesting to reactivate the `nSequence` field which Satoshi preiviously had deactivated.footnote:HearnBitcoinDev[]
-Also Hearn refered to a section on the contracts article talking about the case of micropayment channels with the help of `nSequence`
+It was 2013 that Bitcoin developer Mike Hearn referred to Meni Rosenfelds proposal and suggesting to reactivate the `nSequence` field which Satoshi preiviously had deactivated.footnote:HearnBitcoinDev[]
+Also Hearn referred to a section on the contracts article talking about the case of micropayment channels with the help of `nSequence`
 
 Links:
 * https://en.bitcoin.it/w/index.php?title=Contract&oldid=36712#Example_7:_Rapidly-adjusted_.28micro.29payments_to_a_pre-determined_party

--- a/ch01.asciidoc
+++ b/ch01.asciidoc
@@ -26,7 +26,7 @@ ____
 While James A. Donald was probably referring to maintenance of the unspent transaction outputs (UTXOs) database, it quickly became clear that verifying and storing so many transactions would also become infeasible for any blockchain.
 
 A key requirement for a second layer protocol such as Lightning (which will be described in greater depth later in this book) is the ability to sequence transactions external to the blockchain. In the first versions of Bitcoin, Satoshi Nakamoto recognised this and introduced a data field called `nSequence` into the input transaction data.
-The `nSequence` field was intended to allow users to transmit updated versions of a transaction to the network, changing the outputs of a transaction, effectively creating a payment channel. 
+The `nSequence` field was intended to allow users to transmit updated versions of a transaction to the network, changing the outputs of a transaction, effectively creating a payment channel.
 Such a payment channel would then be valid as long as the transaction was not mined.
 According to a Mailinglist post in 2013 by early Bitcoin developer Mike Hearn, Satoshi Nakamoto envisioned this construction for the use case of high frequency trading.footnote:HearnBitcoinDev[Mike Hearn on Bitcoin-dev - April 16th 2013 - Anti DoS for tx replacement http://web.archive.org/web/20190501234757/https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2013-April/002433.html.]
 
@@ -49,10 +49,10 @@ Whenever she wanted to do so she could create a newer spend of the funding trans
 This transaction could not be mined without a signature from Bob.
 Alice would send the partially signed transaction to Bob how would sign it and keep it private.
 Note that keeping it private and not sharing the fully signed transaction back to Alice is crucial.
-Since Alice never has both signatures for a spend of the multisignature wallet besides the timelocked refund transaction she can't send an outdated spend of the funding transaction to the bitcoin network. 
+Since Alice never has both signatures for a spend of the multisignature wallet besides the timelocked refund transaction she can't send an outdated spend of the funding transaction to the bitcoin network.
 Bob on the other hand could do so but he would have no interest in publishing an old state since a newer state would always provide him with more bitcoin than any older state.
-Alice is not able to have the refund transaction mined into a block before the timelock expires. 
-This gives Bob the security to receive more updates as long as the channel would be `open`. 
+Alice is not able to have the refund transaction mined into a block before the timelock expires.
+This gives Bob the security to receive more updates as long as the channel would be `open`.
 
 This mechanism would allow two users to engage into several smaller transactions which all happened outside of the Bitcoin network.
 While this construction of the unidirectional payment channel would have solved the custody problem of exchanges it has never been widely implemented.
@@ -79,7 +79,7 @@ The Ultra Transaction server was proposed to be a trusted partner of a 2-2 multi
 Andresen observed that with such a mechanism, payments would effectively take place offchain, allowing the number of transacations which could be handled by the system to be increased.
 Andresen noted that there might be a better construction which would require less trust in the Ultra Server, and while his proposal was a step in the right direction, a few issues remained to be solved before the design of fully trustless payment channels was complete.
 
-Andresen's work led to many discussions on Bitcointalk forum, and later on the bitcoin-development mailing list. These discussions resulted in the first construction of the first unidirectional payment channels. 
+Andresen's work led to many discussions on Bitcointalk forum, and later on the bitcoin-development mailing list. These discussions resulted in the first construction of the first unidirectional payment channels.
 
 to sum this up: Andresen used a similar construction as the unidirectional channel.
 They key difference was that a trusted party would have co-signed the spend of the funding transaction.
@@ -98,9 +98,9 @@ Links:
 * https://en.bitcoin.it/w/index.php?title=Contract&oldid=36712#Example_7:_Rapidly-adjusted_.28micro.29payments_to_a_pre-determined_party
 
 
-* Multiple white papers 
+* Multiple white papers
 ** Joseph Poon, Thaddeus Dryja - The Bitcoin Lightning Network:
-Scalable Off-Chain Instant Payments https://lightning.network/lightning-network-paper.pdf  
+Scalable Off-Chain Instant Payments https://lightning.network/lightning-network-paper.pdf
 ** Christian Decker, Roger Wattenhoffer - A Fast and Scalable Payment Network with
 Bitcoin Duplex Micropayment Channels
  https://tik-old.ee.ethz.ch/file/716b955c130e6c703fac336ea17b1670/duplex-micropayment-channels.pdf
@@ -132,7 +132,7 @@ A person or platform offering content on the web.
 They want to install a pay wall or get tipped by their fans and consumers.
 This could even include music or video streaming on demand paying in real time.
 
-John is a 9 year old boy from Australia, who wanted a games console just like his friends. However he was told by his dad that in order to buy it, he had to earn the money by himself.  Now John is an aspiring artist so he knows that while he is still learning, he can't charge much for his artwork.  After learning about Bitcoin, he managed to setup a website to sell his drawings across the internet. By using the Lightning Network, John was able to charge as little as $1 for one of his drawings.  By being able to set a fair price, which would normally be considered a micropayment and as such not possible with other payment methods, and by using a global currency such as Bitcoin, John was able to sell his art work to customers all over the world and in the end buy the games console he so very much wanted. 
+John is a 9 year old boy from Australia, who wanted a games console just like his friends. However he was told by his dad that in order to buy it, he had to earn the money by himself.  Now John is an aspiring artist so he knows that while he is still learning, he can't charge much for his artwork.  After learning about Bitcoin, he managed to setup a website to sell his drawings across the internet. By using the Lightning Network, John was able to charge as little as $1 for one of his drawings.  By being able to set a fair price, which would normally be considered a micropayment and as such not possible with other payment methods, and by using a global currency such as Bitcoin, John was able to sell his art work to customers all over the world and in the end buy the games console he so very much wanted.
 
 gamer::
 Similar to the content creator, a gamer and live streamer would like to be tipped.
@@ -153,11 +153,11 @@ They usually pay fees for using point of sales services and several payment meth
 This directly decreases the margin on which merchants operate.
 A merchant will be happy to get an additional payment method which is virtually for free to the merchant.
 
-An example of a merchant is Silke. 
-Silke runs a small coffee shop in an upmarket street in Berlin. 
-She knows about Bitcoin and wants to accept it in her shop, but has been reluctant to do so because she knows that Bitcoin payments take approx. 10 minutes to be confirmed into her account. 
-However with the Lightning Network, she knows that her regular clients, such as Joerg can pay for their coffee at her shop, quickly and with negligible fees. 
-Additionally, by using the Lightning Network, Silke has all funds deposited instantly to her wallet and with usually smaller fees on her side as well. 
+An example of a merchant is Silke.
+Silke runs a small coffee shop in an upmarket street in Berlin.
+She knows about Bitcoin and wants to accept it in her shop, but has been reluctant to do so because she knows that Bitcoin payments take approx. 10 minutes to be confirmed into her account.
+However with the Lightning Network, she knows that her regular clients, such as Joerg can pay for their coffee at her shop, quickly and with negligible fees.
+Additionally, by using the Lightning Network, Silke has all funds deposited instantly to her wallet and with usually smaller fees on her side as well.
 Ultimately this allows her to provide a better service or to offer better pricing for her products.
 
 

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -246,7 +246,7 @@ Noise_XK::
     K means that the public key of the receiver needs to be known.
     More particular (from: http://www.noiseprotocol.org/noise.html) the protocol enables.
     Encryption to a known recipient, strong forward secrecy. This payload is encrypted based on an ephemeral-ephemeral DH as well as an ephemeral-static DH with the recipient's static key pair. Assuming the ephemeral private keys are secure, and the recipient is not being actively impersonated by an attacker that has stolen its static private key, this payload cannot be decrypted. Sender authentication resistant to key-compromise impersonation (KCI). The sender authentication is based on an ephemeral-static DH ("es" or "se") between the sender's static key pair and the recipient's ephemeral key pair. Assuming the corresponding private keys are secure, this authentication cannot be forged.
-    // the noice protocol documentation is according to their IPR section public domain. The author is Trevor Perrin (noise@trevp.net)
+    // the noise protocol documentation is according to their IPR section public domain. The author is Trevor Perrin (noise@trevp.net)
 
 Onion Routing::
     Onion routing is a technique for anonymous communication over a computer network.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -75,24 +75,24 @@ c-lightning::
     Implementation of the Lightning Network Protocol by the Victoria based Blockstream. It is written in C.
 
 Closing Transaction::
-   If both channel partners agree to close a channel they will create a spent of the funding transaction that reflects the most recent commitment transaction.
-   It does not include any Hashed Time Lock Contracts or Revocable Sequence Maturity Contracts.
-   After exchanging signatures for a closing transaction no further channel updates should be made, as this one allows one side to enforce the closing transaction on the blockchain.
-   Mutually closing a channel with the help of a closing transaction has the advantage that less blockchain transactions are required to claim all funds, in comparison to unilaterally forcing a channel close by publishing a commitment transaction. Additionally, funds are for both parties immediately spendable from a closing transaction.
+    If both channel partners agree to close a channel they will create a spent of the funding transaction that reflects the most recent commitment transaction.
+    It does not include any Hashed Time Lock Contracts or Revocable Sequence Maturity Contracts.
+    After exchanging signatures for a closing transaction no further channel updates should be made, as this one allows one side to enforce the closing transaction on the blockchain.
+    Mutually closing a channel with the help of a closing transaction has the advantage that less blockchain transactions are required to claim all funds, in comparison to unilaterally forcing a channel close by publishing a commitment transaction. Additionally, funds are for both parties immediately spendable from a closing transaction.
 
 coinbase::
-	A special field used as the sole input for coinbase transactions. The coinbase allows claiming the block reward and provides up to 100 bytes for arbitrary data.
+    A special field used as the sole input for coinbase transactions. The coinbase allows claiming the block reward and provides up to 100 bytes for arbitrary data.
     The block reward consists of two things.
     First newly generated coins. The amount of allowed coins to be generated is part of the consensus rules and decreases over time based on the current block height.
     In addition to the newly generated coins, the miner is also allowed to add all the fees of the transactions from the current block to the coinbase.
     Not to be confused with Coinbase transaction.
 
 coinbase transaction::
-	The first transaction in a block. Always created by a miner, it includes a single coinbase.
-	Not to be confused with Coinbase.
+    The first transaction in a block. Always created by a miner, it includes a single coinbase.
+    Not to be confused with Coinbase.
 
 cold storage::
-	Refers to keeping a reserve of bitcoin offline. Cold storage is achieved when Bitcoin private keys are created and stored in a secure offline environment. Cold storage is important for anyone with bitcoin holdings. Online computers are vulnerable to hackers and should not be used to store a significant amount of bitcoin.
+    Refers to keeping a reserve of bitcoin offline. Cold storage is achieved when Bitcoin private keys are created and stored in a secure offline environment. Cold storage is important for anyone with bitcoin holdings. Online computers are vulnerable to hackers and should not be used to store a significant amount of bitcoin.
 
 Commitment Transaction::
     Commitment Transactions encode the balance of the payment channel with the help of one output for each channel partner by spending the funding transaction.
@@ -111,7 +111,7 @@ Computationally Hard::
     A problem is considered to be computationally hard if no algorithm exists or is known that is able to compute the solution to the problem rather quickly.
 
 confirmations::
-	Once a transaction is included in a block, it has one confirmation. As soon as _another_ block is mined on the same blockchain, the transaction has two confirmations, and so on. Six or more confirmations are considered sufficient proof that a transaction cannot be reversed.
+    Once a transaction is included in a block, it has one confirmation. As soon as _another_ block is mined on the same blockchain, the transaction has two confirmations, and so on. Six or more confirmations are considered sufficient proof that a transaction cannot be reversed.
 
 Contract::
     A contract is a set of Bitcoin transactions which result together in a certain desired behavior.
@@ -155,7 +155,7 @@ Ephemeral Key::
     Even if an ephemeral key leaks, only information about a single payment becomes public.
 
 fees::
-	The sender of a transaction often includes a fee to the network for processing the requested transaction.
+    The sender of a transaction often includes a fee to the network for processing the requested transaction.
     Not to be confused with a routing fee for payments on the lightning network.
     Nodes on the Lightning network are allowed to take a routing fee for forwarding payments.
     The routing fee is the sum of a fixed _base_fee_ and a _fee_rate_ which depends on the payment amount.
@@ -361,7 +361,7 @@ Second stage HTLC::
     tbd.
 
 secret key (aka private key)::
-	The secret number that unlocks bitcoin sent to the corresponding address.  pass:[<span class="keep-together">A secret</span>] key looks like the following:
+    The secret number that unlocks bitcoin sent to the corresponding address.  pass:[<span class="keep-together">A secret</span>] key looks like the following:
 +
 ----
 5J76sF8L5jTtzE96r66Sf8cka9y44wdpJjMwCxR3tzLh3ibVPxh

--- a/topics.asciidoc
+++ b/topics.asciidoc
@@ -189,14 +189,14 @@ Creating Lightning Network Applications
 
 === comparisons and examples
 The following is a loose list of potential infoboxes, tables and dropins which will most likely make it to some part of the book.
-They have particular illustrative purpose and are therefore collected seperately to keep better track of them.
+They have particular illustrative purpose and are therefore collected separately to keep better track of them.
 
 ==== comparisons
 * payment process on Bitcoin vs payment process on the lightning network
 * transaction vs payment
 * capacity vs balance
 * routing fees vs mining fees
-* private vs public channel (difficulty to have truely private channels that don't reveal over time on the blockchain?)
+* private vs public channel (difficulty to have truly private channels that don't reveal over time on the blockchain?)
 * source based routing vs best effort routing (onion routing vs IP forwarding)
 * eltoo vs RSMC (?)
 * private key vs fully signed transaction (it can be seen as almost the same in the sense of ownership)

--- a/topics.asciidoc
+++ b/topics.asciidoc
@@ -52,7 +52,7 @@ Review of some mechanics and terms from Mastering Bitcoin. This would probably b
 
 === Motivation: Why the Lightning Network
 
-* clear definition what does scaling of a computer system mean? (I realize that discussions often fail because that term is not well defined among participants. A similar definition might be necessary for Decentralized and trustless) 
+* clear definition what does scaling of a computer system mean? (I realize that discussions often fail because that term is not well defined among participants. A similar definition might be necessary for Decentralized and trustless)
 * Scale Payments (amount of possible payments independent of block size / data base size)
 * increase privacy (not all payments stored on chain)
 * decrease settlement time (get rid of confirmations)


### PR DESCRIPTION
Add linter to make sure Unix style line endings are used.

Enforces the following rule from `CONTRIBUTING.md`:

> All submission should use Unix-like line endings: LF (not CR, not CR/LF). All the postprocessing is done on Unix-like systems. Incorrect line endings, or changes to line endings cause confusion for the diff tools and make the whole file look like it has changed.