### PR TITLE
Add eclair to the list of server implementations

### DIFF
--- a/ch01.asciidoc
+++ b/ch01.asciidoc
@@ -187,8 +187,9 @@ Lightning wallets can be installed on a variety of devices, including laptops, s
 Here are some current examples of LN node and wallet applications for different types of devices:
 
 |===
-| Application | Device | LN Node | Bitcoin Node | Wallet Type |
-| lnd | Server | Full Node | Optional | Full Control |
-| c-lightning | Server | Full Node | Full Node | Full Control |
-| Zap Desktop | Desktop | Full Node | Full Node | Full Control |
-| Eclair | Mobile | Lightweight |
+| Application   | Device  | LN Node     | Bitcoin Node          | Wallet Type  |
+| lnd           | Server  | Full Node   | Bitcoin Core/btcd     | Full Control |
+| c-lightning   | Server  | Full Node   | Bitcoin Core          | Full Control |
+| eclair        | Server  | Full Node   | Bitcoin Core/Electrum | Full Control |
+| Zap Desktop   | Desktop | Full Node   | Bitcoin Core/btcd     | Full Control |
+| Eclair Mobile | Mobile  | Lightweight | Electrum              | Full Control |


### PR DESCRIPTION
Even though Eclair is known for its mobile wallets, its primary work
is a server implementation aimed at scalable enterprise deployments.
It doesn't seem fair to not even include it in the list.

I also slightly changed what's in the "Bitcoin Node" column.
Full Node vs Optional didn't make a lot of sense to me (all LN nodes
really need some kind of bitcoin full node).
I don't know if specifying the exact node implementation (like I did)
makes sense, let me know if you have other ideas.