### PR TITLE
Upper/lower case for the "B" in "Bitcoin" unified

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -1,10 +1,10 @@
 [preface]
 == Quick Glossary
 
-This quick glossary contains many of the terms used in relation to bitcoin. These terms are used throughout the book, so bookmark this for a quick reference.
+This quick glossary contains many of the terms used in relation to Bitcoin. These terms are used throughout the book, so bookmark this for a quick reference.
 
 address::
-    A bitcoin address looks like +1DSrfJdB2AnWaFNgSbv3MZC2m74996JafV+. It consists of a string of letters and numbers. It's really an encoded base58check version of a public key 160-bit hash. Just as you ask others to send an email to your email address, you would ask others to send you bitcoin to one of your bitcoin addresses.
+    A Bitcoin address looks like +1DSrfJdB2AnWaFNgSbv3MZC2m74996JafV+. It consists of a string of letters and numbers. It's really an encoded base58check version of a public key 160-bit hash. Just as you ask others to send an email to your email address, you would ask others to send you bitcoin to one of your Bitcoin addresses.
 
 Asymmetric Cryptographic System::
     Asymmetric cryptography, or public-key cryptography, is a cryptographic system that uses pairs of keys: public keys which may be disseminated widely, and private keys which are known only to the owner.
@@ -31,10 +31,10 @@ bech32::
     A checksummed base32 address format. It is native to segregated (BIP173). Also referred to as "bc1" because of the starting values of each address. Transactions made using bech32 are smaller in most cases, and therefore, may only require a lower fee.
 
 bip::
-    Bitcoin Improvement Proposals. A set of proposals that members of the bitcoin community have submitted to improve bitcoin. For example, BIP-21 is a proposal to improve the bitcoin uniform resource identifier (URI) scheme.
+    Bitcoin Improvement Proposals. A set of proposals that members of the Bitcoin community have submitted to improve Bitcoin. For example, BIP-21 is a proposal to improve the Bitcoin uniform resource identifier (URI) scheme.
 
-bitcoin::
-    Depending on context, bitcoin could refer to the name of the currency unit (the coin), the network, or the underlying enabling protocol.
+Bitcoin::
+    Depending on context, bitcoin could refer to the name of the currency unit (the coin), the network or the underlying enabling protocol. Written as bitcoin with a "b" in lowercase usually refers to the currency unit.
 
 Bitcoin Mining::
     Bitcoin mining serves two purposes.
@@ -52,7 +52,7 @@ Blockchain::
     New blocks have a statistical probability of being produced every ten minutes.
 
 BOLT::
-    BOLT, or Basics Of Lightning Technology, is the formal specification of the Lightning Network Protocol. It serves only as such without delving into implementation, unlike bitcoin, in which both are one and the same. It is available in its entirety on the lightning network's github page, in the lightning-rfc repository.
+    BOLT, or Basics Of Lightning Technology, is the formal specification of the Lightning Network Protocol. It serves only as such without delving into implementation, unlike Bitcoin, in which both are one and the same. It is available in its entirety on the lightning network's github page, in the lightning-rfc repository.
 
 Breach Remedy Transaction::
     A transaction claiming the outputs of a Revocable Sequence Maturity Contract with the help of the revocation key.
@@ -177,7 +177,7 @@ Gossip Protocol::
     Usually Lightning nodes connect with their channel partners, but it is fine to connect with any other Lightning node in order to process gossip messages.
 
 hardware wallet::
-    A hardware wallet is a special type of bitcoin wallet, which stores the user's private keys in a secure hardware device.
+    A hardware wallet is a special type of Bitcoin wallet, which stores the user's private keys in a secure hardware device.
     Currently hardware wallets are not available for lightning network nodes as user nodes need to be online to follow through the protocol.
     Several groups are working on solutions.
 
@@ -210,7 +210,7 @@ Lightning Message::
    A Lightning message is an encrypted data string that can be send between two peers on the Lightning Network. Similar to other communication protocols lightning messages consist of a header and a body. The header and the body have their own HMAC. This ensures that the headers of fixed length will also be encrypted and adversaries won't be able to figure out what messages are being send by inspecting the length.
 
 Lightning Network::
-   The Lightning Network is a protocol on top of bitcoin (or other cryptocurrencies).
+   The Lightning Network is a protocol on top of Bitcoin (or other cryptocurrencies).
    It creates a network of payment channels which enables the trustless forwarding of payments through the network with the help of HTLCs and Onion Routing.
    Other components of the lightning network are the gossip protocol, the transport layer and payment requests.
 
@@ -233,7 +233,7 @@ Millisatoshi::
     The value cannot be enforced on chain.
 
 multisignature::
-    Multisignature (multisig) refers to requiring more than one key to authorize a bitcoin transaction.
+    Multisignature (multisig) refers to requiring more than one key to authorize a Bitcoin transaction.
     Payment channels are always encoded as multisignature addresses requiring one signature from each peer of the payment channel.
     In the standard case of a 2 party payment channel a 2-2 multisignature address is used.
 
@@ -258,7 +258,7 @@ output::
     Output, transaction output, or TxOut is an output in a transaction which contains two fields: a value field for transferring zero or more satoshis and a pubkey script for indicating what conditions must be fulfilled for those satoshis to be further spent.
 
 P2PKH::
-    Transactions that pay a bitcoin address can contain P2PKH or Pay To PubKey Hash scripts. An output locked by a P2PKH script can be unlocked (spent) by presenting a public key and a digital signature created by the corresponding private key.
+    Transactions that pay a Bitcoin address can contain P2PKH or Pay To PubKey Hash scripts. An output locked by a P2PKH script can be unlocked (spent) by presenting a public key and a digital signature created by the corresponding private key.
 
 P2SH::
     P2SH or Pay-to-Script-Hash is a powerful type of transaction that greatly simplifies the use of complex transaction scripts. With P2SH the complex script that details the conditions for spending the output (redeem script) is not presented in the locking script. Instead, only a hash of it is in the locking script.
@@ -280,7 +280,7 @@ Payment::
     This payment hash is used by the Hashed Time Lock Contracts during the routing process.
 
 payment channels::
-    A micropayment channel or payment channel is a class of techniques designed to allow users to make multiple bitcoin transactions without committing all of the transactions to the bitcoin blockchain. In a typical payment channel, only two transactions are added to the block chain, but an unlimited or nearly unlimited number of payments can be made between the participants.
+    A micropayment channel or payment channel is a class of techniques designed to allow users to make multiple Bitcoin transactions without committing all of the transactions to the Bitcoin blockchain. In a typical payment channel, only two transactions are added to the block chain, but an unlimited or nearly unlimited number of payments can be made between the participants.
 
 Payment Channel::
     Payment Channels are the core building blocks of the Lightning Network.
@@ -308,7 +308,7 @@ Preimage::
     Yet it is still believed to be computationally hard to find such a preimage.
 
 Proof-of-Work::
-    A piece of data that requires significant computation to find. In bitcoin, miners must find a numeric solution to the SHA256 algorithm that meets a network-wide target, the difficulty target.
+    A piece of data that requires significant computation to find. In Bitcoin, miners must find a numeric solution to the SHA256 algorithm that meets a network-wide target, the difficulty target.
 
 Relative Timelock::
     TBD.
@@ -365,7 +365,7 @@ secret key (aka private key)::
 ----
 
 Segregated Witness::
-    Segregated Witness is an upgrade to the Bitcoin protocol, which technological innovation separates signature data from bitcoin transactions. Segregated Witness was deployed as a soft fork; a change that technically makes Bitcoin’s protocol rules more restrictive.
+    Segregated Witness is an upgrade to the Bitcoin protocol, which technological innovation separates signature data from Bitcoin transactions. Segregated Witness was deployed as a soft fork; a change that technically makes Bitcoin’s protocol rules more restrictive.
 
 SHA::
     The Secure Hash Algorithm or SHA is a family of cryptographic hash functions published by the National Institute of Standards and Technology (NIST).
@@ -420,6 +420,6 @@ upstream payment::
     TBD.
 
 wallet::
-    Software that holds all your bitcoin addresses and secret keys. Use it to send, receive, and store your bitcoin.
+    Software that holds all your Bitcoin addresses and secret keys. Use it to send, receive, and store your bitcoin.
 
-Some contributed definitions have been sourced under a CC-BY license from the https://en.bitcoin.it/wiki/Main_Page[bitcoin Wiki], https://en.wikipedia.org[Wikipedia], https://github.com/bitcoinbook/bitconbook[Mastering Bitcoin] or from other open source documentation sources.
+Some contributed definitions have been sourced under a CC-BY license from the https://en.bitcoin.it/wiki/Main_Page[Bitcoin Wiki], https://en.wikipedia.org[Wikipedia], https://github.com/bitcoinbook/bitconbook[Mastering Bitcoin] or from other open source documentation sources.


### PR DESCRIPTION
Written as bitcoin with a "b" in lowercase usually refers to the currency unit. A capitalized first letter addresses the network or protocol.

I changed every mentioning of "Bitcoin" in this document accordingly and extended the Bitcoin section to include this distinction. If the change is accepted, I'd check the other files regarding this.