### PR TITLE
CH1 minor edits and suggestions

### DIFF
--- a/ch01.asciidoc
+++ b/ch01.asciidoc
@@ -4,13 +4,13 @@
 
 === What is the Lightning Network?
 
-The Lightning Network (LN) is a "second layer" protocol on top of Bitcoin and other blockchains that enables fast, secure, private, trustless and permissionless payments.
+The Lightning Network (LN) is a "second layer" protocol on top of Bitcoin and other blockchains that enables fast, secure, private, trustless, and permissionless payments.
 
-Users of the LN are able to route payments to each other for very low cost and in real time.
+Users of the LN can route payments to each other for very low cost and in real time.
 Users who transact on the LN do not need to wait for block confirmations for payments.
 Once a payment on the LN has completed, usually within a few seconds, it is final and cannot be reversed: like a  Bitcoin transaction, a payment on the LN can only be refunded by the recipient.
-While "on-chain" Bitcoin transactions are broadcast and verified by all nodes in the network, transactions routed on the LN are transmitted between pairs of nodes and not visible to everyone, resulting in much greater privacy.
-The LN uses onion routing, similar to the protocol used by The Onion Router (TOR) privacy network, so that even the nodes involved in routing a transaction are only directly aware of their predecessor and successor in route.
+While "on-chain" Bitcoin transactions are broadcast and verified by all nodes in the network, transactions routed on the LN are transmitted between pairs of nodes and are not visible to everyone, resulting in much greater privacy.
+The LN uses onion routing, similar to the protocol used by The Onion Router (TOR) privacy network, so that even the nodes involved in routing a transaction are only directly aware of their predecessor and successor en route.
 
 === Motivation for the Lightning Network
 
@@ -22,33 +22,33 @@ The LN uses onion routing, similar to the protocol used by The Onion Router (TOR
 // TODO Introduce and briefly explain the basic concepts of the LN
 
 [[user-stories]]
-=== Lightning Network Uses, Users, and Their Stories
+=== Lightning Network Use Cases, Users, and Their Stories
 
-As an electronic cash system Bitcoin preserves the 3 most important properties of money (medium of exchange, store of value, and unit of account).
+As an electronic cash system, Bitcoin preserves the three most important properties of money (medium of exchange, store of value, and unit of account).
 The invention of money (and in particular Bitcoin) was primarily made to facilitate trade and enable the exchange of value between people.
-However, without the LN, Bitcoin is hard to be used concurrently by millions of people.
+However, without the LN, it would be infeasible for millions of people to concurrently use Bitcoin as a medium of exchange.
 Therefore, in order to fully understand the uses of the LN, we'll examine it from the perspective of people using it.
-In particular the use cases will come from previous users of Bitcoin as well as people who have not used Bitcoin before.
+In particular, the use cases will come from previous users of Bitcoin as well as people who have not used Bitcoin before.
 Each of the people and their stories, as listed here, illustrates one or more specific use cases.
 We'll be seeing them throughout this book:
 
 consumer::
-Alice is a bitcoin user who wants to make fast, secure, cheap and private payments for small amount retail purchases. She buys coffee with bitcoin, using the Lightning Network
+Alice is a bitcoin user who wants to make fast, secure, cheap, and private payments for small retail purchases. She buys coffee with bitcoin, using the Lightning Network.
 
-merchants::
+merchant::
 Bob owns a coffee shop, "Bob's Cafe". "On-chain" bitcoin payments don't scale for small amounts like a cup of coffee, so he uses the Lightning Network to accept bitcoin payments almost instantaneously and for very low fees.
 
 web designer::
-Saanvi is a web designer and developer in Bangalore India. She accepts bitcoin for her work, but would prefer to get paid more frequently and so uses the Lightning Network to get paid for each small milestone she completes. With the LN can do more small jobs for more clients without worrying about fees or delays.
+Saanvi is a web designer and developer in Bangalore India. She accepts bitcoin for her work, but would prefer to get paid more frequently and so uses the Lightning Network to get paid for each small milestone she completes. With the LN, she can do more small jobs for more clients without worrying about fees or delays.
 
 content creator / curator::
-John is a 9 year old boy from New Zealand, who wanted a game console just like his friends. However, his dad told him that in order to buy it, he had to earn the money by himself. Now John is an aspiring artist so he knows that while he is still learning, he can't charge much for his artwork. After learning about Bitcoin, he managed to setup a website to sell his drawings across the internet. By using the LN, John was able to charge as little as $1 for one of his drawings. By being able to set a fair price, which would normally be considered a micro-payment and as such not possible with other payment methods, and by using a global currency such as Bitcoin, John was able to sell his art work to customers all over the world and in the end buy the game console he wanted so much.
+John is a 9-year-old boy from New Zealand, who wanted a games console just like his friends. However, his dad told him that in order to buy it, he had to earn the money by himself. Now John is an aspiring artist, so he knows that while he is still improving, he can't charge much for his artwork. After learning about Bitcoin, he managed to set up a website to sell his drawings across the internet. By using the LN, John was able to charge as little as $1 for one of his drawings, which would normally be considered a micro-payment and, as such, not possible with other payment methods. Furthermore, by using a global currency such as Bitcoin, John was able to sell his artwork to customers all over the world and, in the end, buy the games console he so desperately wanted.
 
 gamer::
-Gloria is a teenage gamer from the Philippines. She plays many different computer games, but her favorite ones are those that have an "in-game economy" based on real money. As she plays games, she also earns money by acquiring and selling virtual in-game items. The Lightning Network allows her to transact in small amount for in-game items as well as earn small amounts for completing quests.
+Gloria is a teenage gamer from the Philippines. She plays many different computer games, but her favorite ones are those that have an "in-game economy" based on real money. As she plays games, she also earns money by acquiring and selling virtual in-game items. The Lightning Network allows her to transact in small amounts for in-game items as well as earn small amounts for completing quests.
 
 migrant::
-Farel is an immigrant, who sends money home to his family in Indonesia by working in the Middle East. Remittance companies and banks charge very high fees, and Farel prefers to send smaller amounts more often. Using the Lightning Network, Farel can send bitcoin as often as he wants, with negligible fees.
+Farel is an immigrant who works in the Middle East and sends money home to his family in Indonesia. Remittance companies and banks charge very high fees, and Farel prefers to send smaller amounts more often. Using the Lightning Network, Farel can send bitcoin as often as he wants, with negligible fees.
 
 software service business::
 Wei is an entrepreneur who sells information services related to the Lightning Network, as well as Bitcoin and other cryptocurrencies. Wei is monetizing his API endpoints by implementing micro-payments over the Lightning Network. Additionally, Wei has implemented a liquidity provider service that rents inbound channel capacity on the LN, charging a small bitcoin fee for each rental period.
@@ -56,38 +56,38 @@ Wei is an entrepreneur who sells information services related to the Lightning N
 
 === Getting Started
 
-In this section we will start by choosing the right software to demonstrate the LN and learn by example. We will examine the choices of two users who represent a common use-case for the LN. Alice, a coffee shop customer will be using a LN wallet on her mobile device to buy coffee from Bob's Cafe. Bob, a merchant, will be using a LN node and wallet to run a point-of-sale system at his cafe so he can accept payment over the LN.
+In this section, we will start by choosing the right software to demonstrate the LN and learn by example. We will examine the choices of two users who represent a common use-case for the LN. Alice, a coffee shop customer, will be using a LN wallet on her mobile device to buy coffee from Bob's Cafe. Bob, a merchant, will be using a LN node and wallet to run a point-of-sale system at his cafe so he can accept payment over the LN.
 
 ==== Lightning Nodes
 
 The Lightning Network is accessed via software applications that can speak the Lightning Network protocol. A _Lightning Network Node_ (or simply "node") is a software application that communicates on a peer-to-peer basis with other LN nodes, forming the Lightning _Network_ itself. Nodes also include "wallet" functionality, so they can send and receive payments over the LN and on the Bitcoin network.
 
-Lightning network nodes also need access to the Bitcoin blockchain, or another blockchain such as Litecoin. Users have the highest degree of control by running their own authoritative Bitcoin node and LN node.
+Lightning network nodes also need access to the Bitcoin blockchain (or other blockchains for other cryptocurrencies). Users have the highest degree of control by running their own Bitcoin node and LN node.
 
 However, LN nodes can also use a lightweight Bitcoin client (commonly referred to as Simplified Payment Verification (SPV)) to partially validate the correctness of their blockchain.
 
 ==== Lightning Wallets
 
-The term "Lightning Wallet" is somewhat ambiguous, as it can describe a broad variety of components, combined together with some user interface. The most constituent components of anything called a "Lightning Wallet" may include:
+The term "Lightning Wallet" is somewhat ambiguous, as it can describe a broad variety of components combined with some user interface. The most constituent parts of anything called a "Lightning Wallet" may include:
 
 * A keystore that securely holds secrets, such as private keys.
 * A Lightning Network node that communicates on the Peer-to-Peer network, as described previously.
-* A blockchain node (such as a Bitcoin node), that stores blockchain data and communicates with other blockchain nodes.
-* A channel data store with data about channels on the Lightning Network
-* A channel manager that can open and close Lightning Network channels
-* A path-finding system that can make a path from payment source to payment destination, by connecting channels together.
+* A Bitcoin node that stores blockchain data and communicates with other Bitcoin nodes.
+* A channel data store with data about channels on the Lightning Network.
+* A channel manager that can open and close Lightning Network channels.
+* A path-finding system that can identify a path of connected channels from payment source to payment destination.
 
-A Lightning Wallet may contain all of these functions, acting as a "full" wallet, with no reliance on any third party services. Or, one or more of these components may rely (partially or completely) on third party servers that mediate those functions.
+A lightning wallet may contain all of these functions, acting as a "full" wallet, with no reliance on any third-party services. Or, one or more of these components may rely (partially or entirely) on third-party services that mediate those functions.
 
-A key distinction (pun intended), is whether the keystore function is internal or outsourced. In blockchains, control of keys determines custody of funds, as memorialized by the phrase "your keys, your coins; not your keys, not your coins". Any wallet that outsources management of keys, is called a "custodial" wallet, because a third party (custodian) has control of the user's funds, not the user themselves. A "non-custodial" or "self-custody" wallet by comparison is one where the keystore is part of the wallet and keys are controlled directly by the user.
+A key distinction (pun intended), is whether the keystore function is internal or outsourced. In blockchains, control of keys determines custody of funds, as memorialized by the phrase "your keys, your coins; not your keys, not your coins". Any wallet that outsources management of keys is called a "custodial" wallet, because a third party (custodian) has control of the user's funds, not the user themselves. A "non-custodial" or "self-custody" wallet, by comparison, is one where the keystore is part of the wallet, and keys are controlled directly by the user.
 
-Blockchains, especially open blockchains like Bitcoin, attempt to minimize or eliminate trust in third parties and empower users. This is often called a "trustless" model, though "trust-minimized" is a better term. In such systems, the user trusts the software rules, not third parties. Therefore, the issue of control over keys is a principal consideration when choosing a Lightning Wallet.
+Blockchains, especially open blockchains like Bitcoin, attempt to minimize or eliminate trust in third parties and empower users. This is often called a "trustless" model, though "trust-minimized" is a better term. In such systems, the user trusts the software rules, not third parties. Therefore, the issue of control over keys is a principal consideration when choosing a lightning wallet.
 
-Every other component of a Lightning Wallet brings similar considerations of trust. If all the components are under the control of the user, then the amount of trust in third parties is minimized, bringing maximum power to the user. Of course, this is a direct tradeoff, as with that power comes the responsibility to manage complex software.
+Every other component of a lightning wallet brings similar considerations of trust. If all the components are under the control of the user, then the amount of trust in third parties is minimized, bringing maximum power to the user. Of course, this is a direct tradeoff, as with that power comes the responsibility to manage complex software.
 
 Every user must consider their own technical skills before deciding what type of lightning wallet to use. Those with strong technical skills should use a Lightning Wallet that puts all of the components under the direct control of the user. Those with less technical skill but a desire to control their funds, should choose a _non-custodial_ lightning wallet, even if some of the components (other than the keystore) rely on some trusted third parties.
 
-Finally, those seeking simplicity and convenience, even at the expense of control and security, may choose a custodial lightning wallet. This is the least challenging option, but it _undermines the trust model of cryptocurrency_ and should therefore be considered only as a stepping stone towards more control and self-reliance. 
+Finally, those seeking simplicity and convenience, even at the expense of control and security, may choose a custodial lightning wallet. This is the least challenging option, but it _undermines the trust model of cryptocurrency_ and should, therefore, be considered only as a stepping stone towards more control and self-reliance.
 
 Here are the three broad categories of lightning wallets and the relative degree of control they offer to the user:
 
@@ -99,7 +99,7 @@ Here are the three broad categories of lightning wallets and the relative degree
 |===
 
 
-Lightning wallets can be installed on a variety of devices, including laptops, servers and mobile devices. To run an LN node and an authoritative Bitcoin node you will need to use a server or desktop computer, as mobile devices and laptops are usually not powerful enough in terms of capacity, processing, battery life and connectivity. On a laptop or mobile device you can run a LN node that relies on a third-party Bitcoin node for access to the blockchain.
+Lightning wallets can be installed on a variety of devices, including laptops, servers, and mobile devices. To run an LN node and a Bitcoin node, you will need to use a server or desktop computer, as mobile devices and laptops are usually not powerful enough in terms of capacity, processing, battery life, and connectivity. On a laptop or mobile device, you can run a LN node that relies on a third-party Bitcoin node for access to the blockchain.
 
 Here are some current examples of LN node and wallet applications for different types of devices:
 

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -178,6 +178,7 @@ Many contributors offered comments, corrections, and additions to the book as it
 Following is an alphabetically sorted list of all the GitHub contributors, including their GitHub IDs in parentheses:
 
 * Alpha Q. Smith (@alpha_github_id)
+* Darius E. Parvin (@DariusParvin)
 * Doru Muntean (@chriton)
 * Eduardo Lima III (@elima-iii)
 * Hatim Boufnichel (@boufni95)


### PR DESCRIPTION
At times the Lightning Network is framed as blockchain agnostic, but then most of the time it's assumed we're talking about a Bitcoin LN node. For consistency and brevity, I feel like it's best to mention at the start that the LN is blockchain agnostic, but from then on assume we're using Bitcoin.

There was some inconsistency for the capitalization of "Lightning Wallet". After it's introduction, I went with lowercase, but I think "LN wallet" would also be an option, consistent with "LN node".

I'm not sure specifically what an "Authoritative" Bitcoin node is, but I feel like it would be implied with just "Bitcoin node" and would be less confusing for the reader.

The oxford comma, used before the "and" at the end of a list, is standard in american english.

This is my first PR, so any feedback is welcome!