### PR TITLE
Glossary updates.

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -422,7 +422,6 @@ This makes development a little bit tricky as one cannot easily monitore ones ow
 ** multihop routing (onion necessary only a subset of nodes involved)
 ** locally setting up and setteling htlcs (only peers involved)
 
-
 === Thoughts about Trust
 As long as a person follows the protocol and has their node secured, there is no principle risk of losing funds when participating with the Lightning Network.
 However there is the risk of paying fees when opening a channel.

--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -290,9 +290,9 @@ While this method could be fully executed faster than the good and the bad way t
 Every payment on the Lightning Network starts with a person who wants to receive Bitcoins issuing an invoice.
 The main reason for this process is that it helps to make the payment process over a path of payement channels atomic.
 Atomic means that no node on the path can decide to take the money that is being routed and stop the routing process.
-The payment will either scuccessfully be transfered through the path of nodes or will not have been delivered.
-There are no such things as a partial payment or half successfull payment.
-While Lightning Nodes usually use the encrypted communication channels over the peer to peernetwork to exchange information invoices are being transfered via a second communication channel.
+The payment will either scuccessfully be transferred through the path of nodes or will not have been delivered.
+There are no such things as a partial payment or half successful payment.
+While Lightning Nodes usually use the encrypted communication channels over the peer to peernetwork to exchange information invoices are being transferred via a second communication channel.
 This could be via a Webservice or Email.
 Invoices are usually encoded either as long bech32 strings or as QR codes which makes them easy to be scanned by smartphones.
 Obviously the invoices contains the amount of bitcoin that is requested and a signature of the payee.
@@ -300,25 +300,25 @@ The later is used to extract the address of the payee so that the payer knows wh
 Besides some other meta data the most important but not quite obvious data in the invoice is a Payment Hash.
 
 ==== Payment Hash
-The payee will choose a truely random number `r` and produces the `sha256` of that number which we call the Payment Hash `H(r)`.
+The payee will choose a truly random number `r` and produces the `sha256` of that number which we call the Payment Hash `H(r)`.
 Note that an adversary should have no means of guessing or predicting `r`.
-Using a customer id or the hash of entries of the shopping cart together with a timestamp is not truely random and yields a security risk.
-The payment process of the lightning network is only secure if `r` is choosen completely randomly and is not predictable and as long as the Hash function cannot be inverted.
+Using a customer id or the hash of entries of the shopping cart together with a timestamp is not truly random and yields a security risk.
+The payment process of the lightning network is only secure if `r` is chosen completely randomly and is not predictable and as long as the Hash function cannot be inverted.
 We note that this is not an additional security assumption to Bitcoin as the security of the Hash function is currently what Bitcoin mining is building upon.
 
 ==== Additional Meta Data
 Invoices can encode some other useful meta data.
-For example a short discription.
+For example a short description.
 In case a user has several invoices to pay the user can read the description and make sure what the invoice was about.
-As payment channel do not need to be publically announced the payee can also provide some private channels as routing hints to the invoice.
+As payment channel do not need to be publicly announced the payee can also provide some private channels as routing hints to the invoice.
 These hints can also be used for public channels to point to those channels on which the payee has enough inbound liquidity to actually receive the amount.
 In case the payers lightning node is not able to send the payment over the lightning network invoices can also include a fallback address.
-We would however always recomend to open a new payment channel instead of doing an on chain transaction that does not add an additional payment channel
+We would however always recommend to open a new payment channel instead of doing an on chain transaction that does not add an additional payment channel
 Invoiceses also have an expiry time so that the payee can delete the preimage after some time to free up space.
 
 === Delivering the payment
 
-You have already learnt that payments start with the payee creating an invoice which includes a Payment Hash to make sure that payments are atomic and that noone on the path of payment channels can withold the transfered money to their benefit.
+You have already learnt that payments start with the payee creating an invoice which includes a Payment Hash to make sure that payments are atomic and that no one on the path of payment channels can withhold the transferred money to their benefit.
 In this section we will dive into the ideas and methods that are being used to deliver a payment over the lightning network and utilizie everything that we have used so far.
 We need to introduce one missing protocol of the Lightning Network which is the gossip protocol.
 
@@ -344,7 +344,7 @@ This topology information is crucually needed for delivering payments through th
 
 [NOTE]
 ====
-A major challange for the participants of the lightning network is that the topology information that is being shared by the gossip protocol is only partial.
+A major challenge for the participants of the lightning network is that the topology information that is being shared by the gossip protocol is only partial.
 For example the capacity of the payment channels is shared on the gossip protocol via the `channel_announcement` message.
 However this information is not as useful as the actual distribution of the capacity into a local balance between the two channel partners.
 This is obvious as a node can only forward the amount of bitcoin via a particular payment channel that it actually owns within that channel.
@@ -358,13 +358,13 @@ While Lightning could have been designed to share balance information of channel
 Payments on the Lightning Network are forwarded a long a path of channels from one participant to another one.
 Thus a path of payment channels has to be selected.
 If we knew the exact channel balances of every channel we would easily be able to compute one of the standard path finding algorithms taught in any computer science program to choose a path for the payment.
-This could even be down in a way to optimize the fees that would have to be paid by the payer to the nodes that kindly foward the payment.
+This could even be down in a way to optimize the fees that would have to be paid by the payer to the nodes that kindly forward the payment.
 However as discussed the balance information of all channels is and cannot be available to all participants of the network.
 Thus we need to have some path finding strategy.
 This strategy relates closely to the routing algorithm hat is used.
 As we will see in the next section on the Lightning Network we use a source based onion routing protocol for routing payments.
 This means in particular that the sender of the payment has to find a path through the network.
-As mentioned before with only partial information about the network topology this is a real challange and active research is still being conducted into optimizing this part of the Lightning Network implementations.
+As mentioned before with only partial information about the network topology this is a real challenge and active research is still being conducted into optimizing this part of the Lightning Network implementations.
 The fact that the pathfinding problem is not fully solved for the case of the Lightning Network is a major point of criticism towards the technology.
 On the good side we emphasize that the certainly not optimal strategy - that is currently being used - of probing paths until one has enough liquidity to forward the payment works still rather well.
 Also it is worthwhile to note that this probing is done by the LN node or wallet and is not directly seen by the user of the software.
@@ -372,7 +372,7 @@ The user might only realize that probing is taking place if the payment is not g
 
 [NOTE]
 ====
-On the Internet we use the internet protocol and the IP forwading algorithm to forward internet packages from the sender to the destination.
+On the Internet we use the internet protocol and the IP forwarding algorithm to forward internet packages from the sender to the destination.
 While the TCP/IP protocol stack allows reliable communication by resending packages that are not acknowledged this mechanism could not be reused directly in the lightning network.
 A payment that is not being forwarded would effectivly mean that the money was stolen by a router and the sender cannot just send out another payment.
 While the routing protocol together with the border gateway protocol which are used for data and infrmation transport on the internet have the really nice property of allowing the internet hosts to collaboratively finding a path for the information through the internet we cannot reuse and adopt this protocol for forwarding payments on the Lightninh network.

--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -304,7 +304,7 @@ The payee will choose a truely random number `r` and produces the `sha256` of th
 Note that an adversary should have no means of guessing or predicting `r`.
 Using a customer id or the hash of entries of the shopping cart together with a timestamp is not truely random and yields a security risk.
 The payment process of the lightning network is only secure if `r` is choosen completely randomly and is not predictable and as long as the Hash function cannot be inverted.
-We note that this is not an additional security assumption to Bitcoin as the security of the Hash function is currently what Bitcoin mining is building upon. 
+We note that this is not an additional security assumption to Bitcoin as the security of the Hash function is currently what Bitcoin mining is building upon.
 
 ==== Additional Meta Data
 Invoices can encode some other useful meta data.
@@ -314,7 +314,7 @@ As payment channel do not need to be publically announced the payee can also pro
 These hints can also be used for public channels to point to those channels on which the payee has enough inbound liquidity to actually receive the amount.
 In case the payers lightning node is not able to send the payment over the lightning network invoices can also include a fallback address.
 We would however always recomend to open a new payment channel instead of doing an on chain transaction that does not add an additional payment channel
-Invoiceses also have an expiry time so that the payee can delete the preimage after some time to free up space. 
+Invoiceses also have an expiry time so that the payee can delete the preimage after some time to free up space.
 
 === Delivering the payment
 
@@ -365,9 +365,9 @@ This strategy relates closely to the routing algorithm hat is used.
 As we will see in the next section on the Lightning Network we use a source based onion routing protocol for routing payments.
 This means in particular that the sender of the payment has to find a path through the network.
 As mentioned before with only partial information about the network topology this is a real challange and active research is still being conducted into optimizing this part of the Lightning Network implementations.
-The fact that the pathfinding problem is not fully solved for the case of the Lightning Network is a major point of criticism towards the technology. 
-On the good side we emphasize that the certainly not optimal strategy - that is currently being used - of probing paths until one has enough liquidity to forward the payment works still rather well. 
-Also it is worthwhile to note that this probing is done by the LN node or wallet and is not directly seen by the user of the software. 
+The fact that the pathfinding problem is not fully solved for the case of the Lightning Network is a major point of criticism towards the technology.
+On the good side we emphasize that the certainly not optimal strategy - that is currently being used - of probing paths until one has enough liquidity to forward the payment works still rather well.
+Also it is worthwhile to note that this probing is done by the LN node or wallet and is not directly seen by the user of the software.
 The user might only realize that probing is taking place if the payment is not going though instantly as it usually would.
 
 [NOTE]
@@ -378,24 +378,24 @@ A payment that is not being forwarded would effectivly mean that the money was s
 While the routing protocol together with the border gateway protocol which are used for data and infrmation transport on the internet have the really nice property of allowing the internet hosts to collaboratively finding a path for the information through the internet we cannot reuse and adopt this protocol for forwarding payments on the Lightninh network.
 ====
 
-Of course path finding is trivial if we want to pay our direct channel partner and we have enough balance on our side of the channel to do so. 
-In all other cases information from the gossip protocol is used to help with path finding. 
-This includes which public payment channels are connecting nodes, which capacity the channels have and what fee policies the owners require. 
+Of course path finding is trivial if we want to pay our direct channel partner and we have enough balance on our side of the channel to do so.
+In all other cases information from the gossip protocol is used to help with path finding.
+This includes which public payment channels are connecting nodes, which capacity the channels have and what fee policies the owners require.
 
 ==== Onion routing
 
-If the sending node of a payment has selected a path that is supposed to be used to make the payment the Lightning Network uses an onion routing scheme similar to the famous TOR-network. 
-The routing scheme is called the SPHINX mixformat and will be explained in detail in a later chapter. 
+If the sending node of a payment has selected a path that is supposed to be used to make the payment the Lightning Network uses an onion routing scheme similar to the famous TOR-network.
+The routing scheme is called the SPHINX mixformat and will be explained in detail in a later chapter.
 For now we want to focus on its properties for the transport of payments which we also call onions.
 
-1. The most important property is that a routing node can only see on which channels it received an onion and on which channel to set up an HTLCs and thus to which peer to forward the onion. This means that no routing node can know who initiated the payment and for whom the payment is supposed to be. The exception of course would be if the node is the recipient. In that case it would know that it was the final destination. 
+1. The most important property is that a routing node can only see on which channels it received an onion and on which channel to set up an HTLCs and thus to which peer to forward the onion. This means that no routing node can know who initiated the payment and for whom the payment is supposed to be. The exception of course would be if the node is the recipient. In that case it would know that it was the final destination.
 2. The onions are small enough to fit into a single TCP/IP package and actually even a link layer frame this will make traffic analysis for intruding the privacy of the payments almost impossible
-3. The Onions are constructed in a way that they will always have the same length independent of the position of the processing node along the path. 
-4. Onions can have up to 20 hops included allowing for sufficient long paths. 
-5. The encryption of the onion for every hope uses different ephemeral encryption keys with every single onion. Should a key (in particular the private key of the public node key) leak at some point in time an attacker who collected onions cannot decrypt the other onions that have been stored. 
-6. Errors can be send back from the erring node in an encrypted way to the original sender. This is particular useful as we have seen that Lightning nodes who initiate the Onions select a path without knowing weather every node has enough liquidity along their channels to forward the payment. 
+3. The Onions are constructed in a way that they will always have the same length independent of the position of the processing node along the path.
+4. Onions can have up to 20 hops included allowing for sufficient long paths.
+5. The encryption of the onion for every hope uses different ephemeral encryption keys with every single onion. Should a key (in particular the private key of the public node key) leak at some point in time an attacker who collected onions cannot decrypt the other onions that have been stored.
+6. Errors can be send back from the erring node in an encrypted way to the original sender. This is particular useful as we have seen that Lightning nodes who initiate the Onions select a path without knowing weather every node has enough liquidity along their channels to forward the payment.
 
-As mentioned we will discuss the details of the Onion Format later but we note already that the `Payment Hash` while needed to set up the HTLCs for the payment is not transported within the onions. 
+As mentioned we will discuss the details of the Onion Format later but we note already that the `Payment Hash` while needed to set up the HTLCs for the payment is not transported within the onions.
 The `Payment Hash` is rather included to the Lightning Message that also transports the onion.
 
 ==== Payment Forwarding Algorithm
@@ -406,12 +406,12 @@ The `Payment Hash` is rather included to the Lightning Message that also transpo
 * sending back errors
 
 === Missing bits
-From a computer science perspective the Lightning Network protocol is mainly a peer to peer protocol between its participants. 
-All communication between participants is send via so called Lightning Messages. 
-Most importantnly communication is needed to open and close payment channels, to send and receive onions, to set up and settle or fail htlcs and for exchanging gossip information. 
-The Lightning messages are send in an encrypted way after a peer connection has been established. 
-Establishing the peer connection follows a cryptographic handshake following the Noise Protocol Framework. 
-The Noise Protocol Framework is a collection of templates for cryptographic handshakes and is also used by WhatsApp and Wireguard. 
+From a computer science perspective the Lightning Network protocol is mainly a peer to peer protocol between its participants.
+All communication between participants is send via so called Lightning Messages.
+Most importantnly communication is needed to open and close payment channels, to send and receive onions, to set up and settle or fail htlcs and for exchanging gossip information.
+The Lightning messages are send in an encrypted way after a peer connection has been established.
+Establishing the peer connection follows a cryptographic handshake following the Noise Protocol Framework.
+The Noise Protocol Framework is a collection of templates for cryptographic handshakes and is also used by WhatsApp and Wireguard.
 Using the Noise Protocol Framework makes sure that every message that is send via Lightning is encrypted and authenticated.
 This makes development a little bit tricky as one cannot easily monitore ones own traffic on a tool like wireshark for debugging. footnote:[Luckily tools exist to make developers live easier: https://github.com/nayutaco/lightning-dissector]
 

--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -374,7 +374,7 @@ The user might only realize that probing is taking place if the payment is not g
 ====
 On the Internet we use the internet protocol and the IP forwarding algorithm to forward internet packages from the sender to the destination.
 While the TCP/IP protocol stack allows reliable communication by resending packages that are not acknowledged this mechanism could not be reused directly in the lightning network.
-A payment that is not being forwarded would effectivly mean that the money was stolen by a router and the sender cannot just send out another payment.
+A payment that is not being forwarded would effectively mean that the money was stolen by a router and the sender cannot just send out another payment.
 While the routing protocol together with the border gateway protocol which are used for data and infrmation transport on the internet have the really nice property of allowing the internet hosts to collaboratively finding a path for the information through the internet we cannot reuse and adopt this protocol for forwarding payments on the Lightninh network.
 ====
 

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -108,11 +108,11 @@ coinbase::
     The block reward consists of two things.
     First, newly generated coins. The amount of allowed coins to be generated is part of the consensus rules and decreases over time based on the current block height.
     Second, the miner is also allowed to add all the fees of the transactions from the current block to the coinbase.
-    Not to be confused with Coinbase transaction.
+    Not to be confused with coinbase transaction.
 
 coinbase transaction::
     The first transaction in a block. Always created by a miner, it includes a single coinbase.
-    Not to be confused with Coinbase.
+    Not to be confused with coinbase.
 
 cold storage::
     Refers to keeping a reserve of bitcoin offline. Cold storage is achieved when Bitcoin private keys are created and stored in a secure offline environment. Cold storage is important for anyone with bitcoin holdings. Online computers are vulnerable to hackers and should not be used to store a significant amount of bitcoin.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -335,12 +335,12 @@ Penalty Transaction::
     Look at the breach remedy transaction.
 
 Preimage::
-    In mathematics given a function $f$ and a value $h$ the preimage of $h$ with respect to $f$ is the set of values $R = \{r_1,r_2,...\}$ such that $f(r_i) = h$ for all $\r_i \in R$.
+    In mathematics, given a function $f$ and a value $h$ the preimage of $h$ with respect to $f$ is the set of values $R = \{r_1,r_2,...\}$ such that $f(r_i) = h$ for all $\r_i \in R$.
     In layman's terms, it is the set of values which is mapped to $h$ by the function $f$.
     This preimage set can be empty, finite or infinite.
-    In cryptography the function $f$ is usually taken to be a hash function.
+    In cryptography, the function $f$ is usually taken to be a hash function.
     Cryptographers use the term preimage for an arbitrary element of $R$.
-    In particular when using SHA-256 we should state that each element has an infinite amount of preimages.
+    In particular, when using SHA-256 we should state that each element has an infinite amount of preimages.
     Yet it is still believed to be computationally hard to find such a preimage.
 
 Proof-of-Work::

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -371,7 +371,7 @@ Topology::
     The topology of the Lightning Network describes the shape of the Lightning Network as a mathematical graph.
     Nodes of the graph are the Lightning Network nodes or participants.
     The edges of the graph are the payment channels.
-    The topology of the Lightning Network is publicly broadcasted with the help of the gossip protocol unless nodes decide to act privately.
+    The topology of the Lightning Network is publicly broadcast with the help of the gossip protocol unless nodes decide to act privately.
     This means that the Lightning Network is probably larger than the announced number of nodes.
     Knowing the topology is of particular interest in the source based routing process of payments in which the sender discovers a route.
     Also, the topology is important for features like the autopilot.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -408,7 +408,7 @@ SHA::
     The Secure Hash Algorithm or SHA is a family of cryptographic hash functions published by the National Institute of Standards and Technology (NIST).
 
 short channel id (scid)::
-    Once a channel is established the index of the funding transaction on the blockchain is used as the short channel id to uniquely identify the channel.
+    Once a channel is established, the index of the funding transaction on the blockchain is used as the short channel id to uniquely identify the channel.
     The short channel id consists of 8 bytes referring to 3 numbers.
     In its serialized form it depicts these 3 numbers as decimal values separated by the letter **x**.
     The first number (4 bytes) is the block height.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -150,7 +150,7 @@ Diffie Hellman Key Exchange::
 
 Digital Signature::
     A digital signature is a mathematical scheme for verifying the authenticity of digital messages or documents.
-    A valid digital signature gives a recipient reason to believe that the message was created by a known sender, that the sender cannot deny having sent the message and that the message was not altered in transit.
+    A valid digital signature gives a recipient reason to believe that the message was created by a known sender, that the sender cannot deny having sent the message, and that the message was not altered in transit.
     They can be seen as cryptographic commitments in which the message is not hidden.
     https://en.wikipedia.org/w/index.php?title=Digital_signature&oldid=876680165
 

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -240,7 +240,7 @@ Invoice::
     Invoices can also include a fallback Bitcoin address to which the payment can be made in case no route can be found, as well as hints for routing a payment through a private channel.
 
 Lightning Message::
-   A Lightning message is an encrypted data string that can be sent between two peers on the Lightning Network. Similar to other communication protocols lightning messages consist of a header and a body. The header and the body have their own HMAC. This ensures that the headers of fixed length will also be encrypted and adversaries won't be able to figure out what messages are being send by inspecting the length.
+   A Lightning message is an encrypted data string that can be sent between two peers on the Lightning Network. Similar to other communication protocols lightning messages consist of a header and a body. The header and the body have their own HMAC. This ensures that the headers of fixed length will also be encrypted and adversaries won't be able to figure out what messages are being sent by inspecting the length.
 
 Lightning Network::
    The Lightning Network is a protocol on top of Bitcoin (or other cryptocurrencies).

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -380,7 +380,7 @@ satoshi::
     A satoshi is the smallest denomination of bitcoin that can be recorded on the blockchain. It is the equivalent of 0.00000001 bitcoin and is named after the creator of Bitcoin, Satoshi Nakamoto. ((("satoshi")))
 
 Satoshi Nakamoto::
-    Satoshi Nakamoto is the name used by the person or people who designed Bitcoin and created its original reference implementation, Bitcoin Core. As a part of the implementation, they also devised the first blockchain database. In the process, they were the first to solve the double-spending problem for digital currency. Their real identity remains unknown.
+    Satoshi Nakamoto is the name used by the person or group of people who designed Bitcoin and created its original reference implementation, Bitcoin Core. As a part of the implementation, they also devised the first blockchain database. In the process, they were the first to solve the double-spending problem for digital currency. Their real identity remains unknown.
 
 Script::
     Bitcoin uses a scripting system for transactions. Forth-like, Script is simple, stack-based, and processed from left to right. It is purposefully not Turing-complete, with no loops.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -268,7 +268,7 @@ Millisatoshi::
 multisignature::
     Multisignature (multisig) refers to requiring more than one key to authorize a Bitcoin transaction.
     Payment channels are always encoded as multisignature addresses requiring one signature from each peer of the payment channel.
-    In the standard case of a 2 party payment channel a 2-2 multisignature address is used.
+    In the standard case of a two-party payment channel a 2-2 multisignature address is used.
 
 Noise_XK::
     The template of the Noise protocol framework to establish an authenticated and encrypted communication channel between two peers of the lightning network.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -373,7 +373,7 @@ Topology::
     The edges of the graph are the payment channels.
     The topology of the Lightning Network is publicly broadcast with the help of the gossip protocol unless nodes decide to act privately.
     This means that the Lightning Network is probably larger than the announced number of nodes.
-    Knowing the topology is of particular interest in the source based routing process of payments in which the sender discovers a route.
+    Knowing the topology is of particular interest in the source-based routing process of payments in which the sender discovers a route.
     Also, the topology is important for features like the autopilot.
 
 satoshi::

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -95,7 +95,7 @@ Capacity::
     It is not to be confused with the balance.
 
 c-lightning::
-    Implementation of the Lightning Network Protocol by the Victoria based Blockstream. It is written in C.
+    Implementation of the Lightning Network Protocol by the Victoria-based Blockstream. It is written in C.
 
 Closing Transaction::
     If both channel partners agree to close a channel they will create a spent of the funding transaction that reflects the most recent commitment transaction.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -245,7 +245,7 @@ Lightning Message::
 Lightning Network::
    The Lightning Network is a protocol on top of Bitcoin (or other cryptocurrencies).
    It creates a network of payment channels which enables the trustless forwarding of payments through the network with the help of HTLCs and Onion Routing.
-   Other components of the lightning network are the gossip protocol, the transport layer and payment requests.
+   Other components of the lightning network are the gossip protocol, the transport layer, and payment requests.
 
 Lightning Network Node::
     TBD.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -188,12 +188,12 @@ fees::
 
 Funding Transaction::
     The funding transaction is used to open a payment channel.
-    From the perspective of the Bitcoin network, the process of opening a channel by creating a rsmc is started by creating the funding transaction and finished by broadcasting it to the Bitcoin network and have it included in the blockchain.
+    From the perspective of the Bitcoin network, the process of opening a channel by creating a RSMC is started by creating the funding transaction and finished by broadcasting it to the Bitcoin network and have it included in the blockchain.
     The value of the funding transaction is exactly the capacity of the payment channel.
     The output of the funding transaction is a 2-out-of-2 multisignature script (multisig) where each channel partner controls one key.
     It is supposed to be spent by the commitment transactions or by the closing transaction.
     Due to its multisig nature, it can only be spent mutually.
-    It is part of the rsmc to ensure that either side of the channel can withdraw their funds without the necessity to trust the channel partner.
+    It is part of the RSMC to ensure that either side of the channel can withdraw their funds without the necessity to trust the channel partner.
 
 Globalfeatures::
     Globalfeatures of a Lightning Network node are the features of interest for all other nodes.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -101,7 +101,7 @@ Closing Transaction::
     If both channel partners agree to close a channel they will create an exercise settlement transaction that reflects the most recent commitment transaction.
     It does not include any Hashed Time Lock Contracts or Revocable Sequence Maturity Contracts.
     After exchanging signatures for a closing transaction no further channel updates should be made, as this one allows one side to enforce the closing transaction on the blockchain.
-    Mutually closing a channel with the help of a closing transaction has the advantage that less blockchain transactions are required to claim all funds, in comparison to unilaterally forcing a channel close by publishing a commitment transaction. Additionally, funds are for both parties immediately spendable from a closing transaction.
+    Mutually closing a channel with the help of a closing transaction has the advantage that fewer blockchain transactions are required to claim all funds, in comparison to unilaterally forcing a channel close by publishing a commitment transaction. Additionally, funds are for both parties immediately spendable from a closing transaction.
 
 coinbase::
     A special field used as the sole input for coinbase transactions. The coinbase allows claiming the block reward and provides up to 100 bytes for arbitrary data.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -347,7 +347,7 @@ Proof-of-Work::
     A piece of data that requires significant computation to find. In Bitcoin, miners must find a numeric solution to the SHA256 algorithm that meets a network-wide target, the difficulty target.
 
 Relative Timelock::
-    Relative Timelock is a kind of timelock that allows an input to specify the earliest time it can be added to a block based on how long ago (which is relative) the output refered by that input was included in a block. Such a feature is jointly achieved by nSequence field and CheckSequenceVerify opcode, which are introduced by BIP68/112/113. 
+    Relative Timelock is a kind of timelock that allows an input to specify the earliest time it can be added to a block based on how long ago (which is relative) the output refered by that input was included in a block. Such a feature is jointly achieved by nSequence field and CheckSequenceVerify opcode, which are introduced by BIP68/112/113.
 
 Revocable Sequence Maturity Contract::
     This contract is used to construct a payment channel between two Bitcoin or Lightning Network users who do not need to trust each other.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -419,13 +419,13 @@ Simplified Payment Verification (SPV)::
     SPV or simplified payment verification is a method for verifying particular transactions were included in a block without downloading the entire block. The method is used by some lightweight Bitcoin clients.
 
 Source-Based Routing::
-    On the Lightning Network the sender of a payment decides the route of the payment.
+    On the Lightning Network, the sender of a payment decides the route of the payment.
     While this decreases the success rate of the routing process, it increases the privacy of payments.
     Due to the SPHINX Mix Format used by the Onion Routing, all routing nodes do not know the originator of a payment or the final recipient.
     Source-based routing is fundamentally different to how routing works on the Internet Protocol.
 
 soft fork::
-    Soft fork or Soft-Forking Change is a temporary fork in the blockchain which commonly occurs when miners using non-upgraded nodes don't follow a new consensus rule their nodes don’t know about.
+    Soft fork, or Soft-Forking Change, is a temporary fork in the blockchain which commonly occurs when miners using non-upgraded nodes don't follow a new consensus rule their nodes don’t know about.
     Not to be confused with fork, hard fork, software fork or Git fork.
 
 SPHINX Mix Format::

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -98,7 +98,7 @@ c-lightning::
     Implementation of the Lightning Network Protocol by the Victoria-based Blockstream. It is written in C.
 
 Closing Transaction::
-    If both channel partners agree to close a channel they will create a spent of the funding transaction that reflects the most recent commitment transaction.
+    If both channel partners agree to close a channel they will create an exercise settlement transaction that reflects the most recent commitment transaction.
     It does not include any Hashed Time Lock Contracts or Revocable Sequence Maturity Contracts.
     After exchanging signatures for a closing transaction no further channel updates should be made, as this one allows one side to enforce the closing transaction on the blockchain.
     Mutually closing a channel with the help of a closing transaction has the advantage that less blockchain transactions are required to claim all funds, in comparison to unilaterally forcing a channel close by publishing a commitment transaction. Additionally, funds are for both parties immediately spendable from a closing transaction.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -255,7 +255,7 @@ lnd::
     It is written in Go.
 
 Localfeatures::
-    Localfeatures of a Lightning Network node are the features of direct interest of the peer.
+    Localfeatures of a Lightning Network node are the configurable features of direct interest of the peer.
     They are announced in the `_init_` message of the peer protocol as well as the `_channel_announcement_` and `_node_announcement_` messages of the gossip protocol.
 
 Locktime::

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -347,7 +347,7 @@ Proof-of-Work::
     A piece of data that requires significant computation to find. In Bitcoin, miners must find a numeric solution to the SHA256 algorithm that meets a network-wide target, the difficulty target.
 
 Relative Timelock::
-    Relative Timelock is a kind of timelock that allows an input to specify the earliest time it can be added to a block based on how long ago (which is relative) the output refered by that input was included in a block. Such a feature is jointly achieved by nSequence field and CheckSequenceVerify opcode, which are introduced by BIP68/112/113.
+    Relative Timelock is a kind of timelock that allows an input to specify the earliest time it can be added to a block based on how long ago (which is relative) the output referred by that input was included in a block. Such a feature is jointly achieved by nSequence field and CheckSequenceVerify opcode, which are introduced by BIP68/112/113.
 
 Revocable Sequence Maturity Contract::
     This contract is used to construct a payment channel between two Bitcoin or Lightning Network users who do not need to trust each other.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -240,7 +240,7 @@ Invoice::
     Invoices can also include a fallback Bitcoin address to which the payment can be made in case no route can be found, as well as hints for routing a payment through a private channel.
 
 Lightning Message::
-   A Lightning message is an encrypted data string that can be send between two peers on the Lightning Network. Similar to other communication protocols lightning messages consist of a header and a body. The header and the body have their own HMAC. This ensures that the headers of fixed length will also be encrypted and adversaries won't be able to figure out what messages are being send by inspecting the length.
+   A Lightning message is an encrypted data string that can be sent between two peers on the Lightning Network. Similar to other communication protocols lightning messages consist of a header and a body. The header and the body have their own HMAC. This ensures that the headers of fixed length will also be encrypted and adversaries won't be able to figure out what messages are being send by inspecting the length.
 
 Lightning Network::
    The Lightning Network is a protocol on top of Bitcoin (or other cryptocurrencies).

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -123,7 +123,7 @@ Commitment Transaction::
     One output also holds a Revocable Sequence Maturity Contract which is made to disincentivize a channel partner to broadcast an old commitment transaction to the Bitcoin network.
     This effectively invalidates old commitment transactions.
     Broadcasting a commitment transaction forces a unilateral channel close.
-    Up to 483 Hashed Time Lock Contracts can be stored as additional outputs in the commitment transactions allow the routing of payments.
+    Up to 483 Hashed Time Lock Contracts can be stored as additional outputs in the commitment transaction to allow the routing of payments.
     In order to be able to ascribe blame in the case of unilateral channel closes, each channel partner has a slightly different commitment transaction.
     // TODO probably don't explain the difference with the RSMC here
 

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -106,8 +106,8 @@ Closing Transaction::
 coinbase::
     A special field used as the sole input for coinbase transactions. The coinbase allows claiming the block reward and provides up to 100 bytes for arbitrary data.
     The block reward consists of two things.
-    First newly generated coins. The amount of allowed coins to be generated is part of the consensus rules and decreases over time based on the current block height.
-    In addition to the newly generated coins, the miner is also allowed to add all the fees of the transactions from the current block to the coinbase.
+    First, newly generated coins. The amount of allowed coins to be generated is part of the consensus rules and decreases over time based on the current block height.
+    Second, the miner is also allowed to add all the fees of the transactions from the current block to the coinbase.
     Not to be confused with Coinbase transaction.
 
 coinbase transaction::

--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -164,6 +164,5 @@ Next, we use the +make+ command to build the libraries, components and executabl
 $ make
 ----
 
-
 === eclair
 === lightning network daemon (lnd)

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -175,6 +175,7 @@ Many contributors offered comments, corrections, and additions to the book as it
 Following is an alphabetically sorted list of all the GitHub contributors, including their GitHub IDs in parentheses:
 
 * Alpha Q. Smith (@alpha_github_id)
+* Brian L. McMichael (@brianmcmichael)
 * Darius E. Parvin (@DariusParvin)
 * Doru Muntean (@chriton)
 * Eduardo Lima III (@elima-iii)


### PR DESCRIPTION
Several spelling, punctuation, and grammatical fixes to glossary definitions.

In order to pass the CI check, this PR was based off of https://github.com/lnbook/lnbook/pull/160, which is itself a duplication of https://github.com/lnbook/lnbook/pull/148

#148 should go in first so @HAOYUatHZ gets the credit, and that will clear out the non-glossary related edits from this diff.