### PR TITLE
fix glossary typos

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -259,7 +259,7 @@ Localfeatures::
     They are announced in the `_init_` message of the peer protocol as well as the `_channel_announcement_` and `_node_announcement_` messages of the gossip protocol.
 
 Locktime::
-    Locktime, or more technically nLockTime, is the part of a transaction which indicates the earliest time or earliest block when that transaction may be added to the block chain.
+    Locktime, or more technically nLockTime, is the part of a transaction which indicates the earliest time or earliest block when that transaction may be added to the blockchain.
 
 Millisatoshi::
     The smallest unit of account on the lightning network.
@@ -316,7 +316,7 @@ Payment::
     This payment hash is used by the Hashed Time Lock Contracts during the routing process.
 
 payment channels::
-    A micropayment channel or payment channel is a class of techniques designed to allow users to make multiple Bitcoin transactions without committing all of the transactions to the Bitcoin blockchain. In a typical payment channel, only two transactions are added to the block chain, but an unlimited or nearly unlimited number of payments can be made between the participants.
+    A micropayment channel or payment channel is a class of techniques designed to allow users to make multiple Bitcoin transactions without committing all of the transactions to the Bitcoin blockchain. In a typical payment channel, only two transactions are added to the blockchain, but an unlimited or nearly unlimited number of payments can be made between the participants.
 
 Payment Channel::
     Payment Channels are the core building blocks of the Lightning Network.


### PR DESCRIPTION
Changes "block chain" to "blockchain" twice in glossary