### PR TITLE
improved definition of LN

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -14,7 +14,7 @@ If you are one of those readers you may want to skip this chapter.
 
 We'll start with a one sentence definition of what the Lightning Network (LN) is and break it down in the remainder of this chapter.
 
-**The Lightning Network (LN) is a network of _payment channels_ on top of the _Bitcoin protocol_, as well as a communication protocol that defines how participants set up and execute the smart contracts on the network**
+**The Lightning Network (LN) is both a peer-to-peer network of _payment channels_ on top of the _Bitcoin protocol_ as well as a communication protocol that defines how participants set up and execute the smart contracts on the Bitcoin network**
 
 We will see that a payment channel is simply a 2-out-of-2 multisignature address on the Bitcoin network for which you hold one key and your channel partner holds the other key.
 This multisignature address comes with a cryptographic protocol that is established by creating a sequence of transactions that spend from this address.


### PR DESCRIPTION
- removed incorrect comma in front of "as well as"
- added "both" to underline that LN has 2 main functionalities
- "... on the network." leaves it undefined. The reader might ask to which network it refers to? To the before mentioned network of payment-channels? Added "Bitcoin" to clarify.