### PR TITLE
added a few words to improve definition paragraph

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -18,11 +18,11 @@ We'll start with a one sentence definition of what the Lightning Network (LN) is
 
 We will see that a payment channel is simply a 2-out-of-2 multisignature address on the Bitcoin network for which you hold one key and your channel partner holds the other key.
 This multisignature address comes with a cryptographic protocol that is established by creating a sequence of transactions that spend from this address.
-Each new transaction is negotiated between you and your channel partners and are attempts to spend from the multisignature address.
+Each new transaction is negotiated between you and your channel partner and are attempts to spend from the multisignature address.
 The latest transaction in the sequence encodes the balance of the channel and defines how the funds locked into the multisignature address are to be divided between you and your channel partner.
 Thus adding a new transaction to this sequence is equivalent to moving ownership of funds in the channel, without the Bitcoin network being aware of it.
-Each transaction in the sequence makes use of Bitcoin's scripting language, and thus the negotiation of funds between you and your channel partners is managed by a smart contract.
-The contract is set up so as to penalize a channel member if they try to steal funds by submitting an earlier state of the channel.
+Each transaction in the sequence makes use of Bitcoin's scripting language, and thus the negotiation of funds between you and your channel partner is managed by a Bitcoin smart contract.
+The contract is set up such as to penalize a channel member if it tries to steal funds by submitting an earlier invalidated state of the channel.
 
 [NOTE]
 ====


### PR DESCRIPTION
- consistent use of "partner", singular vs plural
- added "Bitcoin" to "Bitcoin smart contract" because there are many people out there that have heard the term "smart contract" exclusively in the context of Ethereum. It might be worth while to underline that Bitcoin also has its form of smart contracts. This should eliminate any possible doubts.
- imply that earlier states are no longer valid, added "invalidated" 
- channel member is singular, so "if they try" is wrong. better "if it tries"