### PR TITLE
minor corrections in Payment channels paragraphs

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -59,22 +59,22 @@ Besides all the technical primitives, the Lightning Network protocol is a creati
 
 As you have seen in the last chapter, in order to use the Lightning Network, Alice had to use her wallet software to create a payment channel with another LN participant.
 From a computer science perspective a payment channel is a cryptographic communication protocol between you and your channel partner.
-It allows the both of you to send funds back and forth as often as you wish.
-The channel is only limited by two things:
+It allows both of the channel partners to send funds back and forth as often as they wish.
+A channel is only limited by two things:
 First, the time it takes for the internet to transfer the few bytes of data that the protocol requires to make a payment between you and your partner.
-Second, the capacity of the channel, which is the term for the funds that have been assigned to the channel.
+Second, the capacity of the channel, which is the term for the monetary funds, i.e. bitcoin, that have been assigned to and locked up by the channel.
 Payment channels have a couple of very interesting and useful properties.
 
-* If the channel is open, making a payment does not require the confirmation of Bitcoin blocks. In fact - as long as you and your channel partner follow the protocol - it does not require any interaction with the Bitcoin network or anyone else other than your channel partner.
-* The cryptographic protocol is constructed in a way that there is little to no trust involved between you and your channel partner. If your partner becomes unresponsive or tries to cheat on you, you can ask the Bitcoin network to act as a court system resolving the conflict according to the rules that you and your partner have previously agreed upon.
-* The capacity of the channel will be split between you and your partner. In that sense at that level you already will have gained more privacy compared to the Bitcoin network where every transaction is public. Within payment channels the amount and values of payments are kept secret between you and your partner. Only the final balance which is the aggregate of all payments in that channel will become visible on the Bitcoin blockchain if the payment channel is closed.
-* As the time to update the channel is the only bound, making a payment within a payment channel is almost instant.
+* If the channel is open, making a payment does not require the confirmation of Bitcoin blocks. In fact - as long as you and your channel partner follow the protocol - it does not require any interaction with the Bitcoin network or anyone else other than with your channel partner.
+* The cryptographic protocol is constructed in a way that there is little to no trust involved between you and your channel partner. If your partner becomes unresponsive or tries to cheat you, you can ask the Bitcoin network to act as a court system resolving the conflict according to the rules that you and your partner have previously agreed upon.
+* The capacity of the channel will be split between you and your partner. In that sense at that level you already will have gained privacy compared to the Bitcoin network where every transaction is public. Within payment channels the amounts and values of payments are only known to you and your partner. Only the final balance which is the aggregate of all payments in that channel will become visible on the Bitcoin blockchain if and when the payment channel is closed.
+* As the time to update the channel is primarily bound by the communication speed of the internet, making a payment on a payment channel is almost instant.
 
-Bitcoin had to be about 5 years old until talented developers figured out how payment channels could be constructed and by now there are at least 3 different constructions known.
-This chapter will only focus on the "Poon, Dryja" - Construction since it is actually being used in the Lightning Network and was first described in the Lightning Network whitepaper.
-The other two constructions are the Duplex Micropayment channels which have been introduced by Christian Decker around the same time as the "Poon, Dryja" - channels and the "eltoo" - channels which have been introduced in 2018 by Christian Decker, Rusty Russel and our co-author Olaoluwa Osuntokun.
+Bitcoin was about 5 years old when talented developers first figured out how payment channels could be constructed and by now there are at least 3 different methods known.
+This chapter will only focus on the channel construction method proposed by Joseph Poon and Thaddeus Dryja in 2015 since it is actually being used in the Lightning Network and was first described in the Lightning Network whitepaper.
+The two other proposed methods are the "Duplex Micropayment" channels which have been introduced by Christian Decker around the same time as the "Poon and Dryja" channels and the "eltoo" channels which have been introduced in 2018 by Christian Decker, Rusty Russel and our co-author Olaoluwa Osuntokun.
 The later seem much easier to implement and have a couple of nicer properties.
-However they need a new OP_CODE to the Bitcoin scripting language and can currently not be implemented on top of the Bitcoin mainnet.
+However, these "eltoo" channels require a new OP_CODE in the Bitcoin scripting language and can therefore currently not be implemented on top of the Bitcoin mainnet.
 
 ==== Multisig addresses
 Payment channels are smart contracts that build on top of 2-2 multisignature addresses which will be spent by Segwit transactions.


### PR DESCRIPTION
- "the both of you": incorrect English, better "both of you"
- "cheat on you": spoken English, better "cheat you"
- "had to be", that sounds like you are guessing, better "was"
- if you give full names of some, give full names of all 
- added year to make it more precise
- comma after "however"
- etc.