### PR TITLE
minor improvements to Funding Transaction paragraphs

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -117,23 +117,24 @@ The two scripts together would form the combined validation script:
 ----
 
 ==== Funding Transaction
-We have already seen that one of the important building blocks of a payment channel is a 2-of-2 multisignature address.
+We have already seen that one of the important building blocks of a payment channel is a 2-out-of-2 multisignature address.
 To open a payment channel one must send bitcoin to that address.
-The Bitcoin transaction that sends bitcoin to that 2-2 multisignature address, and is included in the Bitcoin blockchain, is called the funding transaction.
-While two participants of the Lightning Network can open a private payment channel, the funding transaction will always be publicly visible to the Bitcoin network.
+The Bitcoin transaction that sends bitcoin to that 2-out-of-2 multisignature address is called the funding transaction. 
+It is included in the Bitcoin blockchain.
+While the payment channel opened by two participants of the Lightning Network can be private, the funding transaction will always be publicly visible to the Bitcoin network.
 The amount of bitcoin sent to the multisignature address forms an upper limit on how much Bitcoin can be transacted using the channel, and is called the capacity of the channel.
-Two channel partners will never be able to conduct larger payments on that channel than the channel capacity.
+Two channel partners will never be able to conduct payments on a channel that are larger than its channel capacity.
 While the Bitcoin network can see that funds have been committed to a channel using a funding transaction, it is unable to determine how those funds are distributed between the two channel partners.
 
 [Note]
 ====
-You will often hear that people complain about bitcoin being locked to the Lightning Network which can't move freely.
-This is obviously a lie.
-One can use the Bitcoin network to send bitcoin from a P2PKH address as well as sending bitcoin from a 2-2 multisignature address with a P2WSH transaction.
-In both cases transfer of ownership might be expensive in bitcoin fees if there is a lot of demand from people to utilize the Bitcoin network.
-However once the bitcoin are used to open a payment channel they can freely flow within the Lightning Network from one participant to another one.
+You might hear people falsely complaining about bitcoin being locked up by the Lightning Network preventing their movement.
+This is incorrect.
+One can use the Bitcoin network to send bitcoin from a P2PKH address as well as from a 2-out-of-2 multisignature address with a P2WSH transaction.
+In both cases transfer of ownership incurs the corresponding bitcoin fees for processing the "on-chain" transaction on the Bitcoin network.
+However, once the bitcoin are used to open a payment channel they can freely flow within the Lightning Network from one participant to another one.
 If a channel partner should not respond, one will always have the chance to fall back to the on-chain transactions without the necessity for the channel partner to help to do so.
-Due to the potentially high fees and confirmation times, bitcoin on the Bitcoin network are way more rigid and harder to move than bitcoin on the Lightning Network.
+On-chain fees and Bitcoin confirmation times make moving bitcoin on the Bitcoin network more expensive and slower than moving bitcoin on the Lightning Network.
 ====
 
 ===== Example of a poor channel opening procedure


### PR DESCRIPTION
- consistently sticking to "2-out-of-2"
- rephrasing some sentences to make them more palatable. "obviously a lie" is a bit aggressive. 
- avoid using exaggerating terms like "very expensive", just state the facts without too many emotions