### PR TITLE
minor improvements in "Example of a poor channel opening procedure"

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -143,8 +143,8 @@ Now Alice prepares a Bitcoin Transaction sending a few mBTC to the multisignatur
 As Alice wasn't aware of the protocol to open the channel she now has to trust that Mallory will provide her signature if Alice wants to spend from the multisignature address.
 Mallory on the other side has the chance to execute a blackmail attack on Alice by holding back her signature and denying Alice access to her funds.
 
-In order to prevent Mallory from committing such an attack Alice will need to create a spend transaction from the funding transaction and have that transaction signed from Mallory before she broadcasts her funding transaction to the Bitcoin network.
-The transaction protecting Alice is called Commitment transaction and we will study it now.
+In order to prevent Mallory from performing such an attack Alice will need to create a spend transaction from the funding transaction and have that transaction signed by Mallory before she broadcasts her funding transaction to the Bitcoin network.
+This transaction that protects Alice is called Commitment transaction and we will study it now.
 
 ==== Commitment Transaction
 


### PR DESCRIPTION
- replace "committing attack" with "performing attack" to avoid that the reader incorrectly concludes that the term "commitment tx" has anything to do with "committing an attack"
- signed by, not signed from