### PR TITLE
minor improvements to chapter "Announcing the channel"

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -214,17 +214,20 @@ She has to wait for the time lock until she can spend her funds from the commitm
 Other than that and the fees for opening and closing a channel there comes no additional burden with maintaining a payment channel.
 
 ==== Announcing the channel
-Channel partners can agree to publicly announce the channel over the gossip protocol that comes with the Lightning Network.
-This is useful as other nodes will then be able to utilize this channel to route payments to other participants of the network.
-Note that even for private channels which are not announced over the gossip protocol, the funding transaction is always publicly stored in the Bitcoin blockchain.
-However as it is just a regular transaction to a 2-2 multisignature address, participants of the Bitcoin network do not know if this particular transaction is used to maintain a payment channel.
-Private channel can still be used in routing payments but only by the subset of nodes which are aware of their existence.
-If a channel and its capacity is publicly announced on the gossip protocol, the channel partners will also be able to announce some meta data about the channel.
-This meta data includes the routing fees a node charges to forward payments on that channel, information about what kind and how many Hash Time-Locked Contracts (HTLCs) will be accepted.
+Channel partners can optionally agree to publicly announce the channel over the gossip protocol that comes with the Lightning Network. Such a channel is called a "public" channel. 
+On the contrary, a channel that is not publicly announced is referred to as a "private" channel and its details are only known to the two channel partners. 
+Announcing channels publicly is useful as other nodes will then be able to utilize the announced channel to route payments via it to other participants of the network.
+Note that even for private channels, the funding transaction is always publicly stored in the Bitcoin blockchain.
+However, as it is just a regular transaction to a 2-out-of-2 multisignature address, participants of the Bitcoin network do not know if this particular transaction is used to maintain a payment channel. 
+In short, the "on-chain" transactions of the Lightning Network are indistinguishable from other Bitcoin transactions. 
+Private channels can still be used in routing payments but only by the subset of nodes which are aware of their existence.
+If a channel and its capacity are publicly announced on the gossip protocol, the channel partners will also be able to announce some meta data about the channel.
+This meta data includes the routing fees a node charges to forward payments on that channel as well as information about what kind and how many Hash Time-Locked Contracts (HTLCs) will be accepted.
 As we have not discussed HTLCs yet we will just mention that they are additional conditional outputs in the commitment transactions used for routing payments and for updating the channel balance.
 We will later investigate HTLCs in more detail.
-When new participants join the Lightning Network they will be able to download the information propagated via the gossip protocol from their peers.
-Peers can only omit messages but as every message is signed by the node that originally sent out the message the information on the gossip protocol cannot be modified to trick other participants.
+When new participants join the Lightning Network they will be able to collect the information propagated via the gossip protocol from their peers.
+Peers can only omit messages.
+Peers cannot falsify messages to trick other participants as every message is cryptographically signed by the publishing node that created the message.
 
 ==== Closing the channel
 The main goal of people using the Lightning Network is to keep their channels open as long as possible.


### PR DESCRIPTION
- added distinction between "public" and "private" channel, added the 2 terms
- rename 2-2 to 2-out-of-2 for consistency and to make it clearer
- simplified a few sentences
- added a few additional clarifying words
- etc