### PR TITLE
minor improvements to chapter "Examining the good way - mutual close"

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -249,16 +249,16 @@ The good news for you is that your Lightning Network software will most likely a
 
 ===== Examining the good way - mutual close
 The preferred and good way to close a channel is the mutual close.
-When you decide that you want to close the channel, your Lightning Network node will inform your channel partner about your intention.
+When you decide that you want to close a channel, your Lightning Network node will inform your channel partner about your intention.
 Now the channel will be prepared for shutting down.
 No new routing attempts will be accepted from either channel partner and the ongoing routing attempts will be settled or removed after they timed out.
 Once no further routing attempts are pending, the closing transaction is prepared.
 This transaction is similar to the commitment transaction.
-It has the same balance as the commitment transaction but no outputs are encumbered with a time lock.
-As the finish up of the routing attempts could take some time, a mutual close can also take some time.
-The on-chain transaction fees of the shutdown transaction for closing the channel in a mutual way are being paid by the party who opened the channel and not as many people think by the person who initiated the closing procedure.
-As both nodes sign the shutdown transaction they have the chance to pay small fees for the Bitcoin transaction by using their on-chain fee estimator.
-Even though there is a potential waiting time, this type of channel close is usually faster than the bad way.
+It has the same balance as the last commitment transaction but no outputs are encumbered with a time lock.
+As finalizing the routing attempts can take some time, a mutual close can also take some time.
+The on-chain transaction fees of the on-chain transaction for closing the channel in a mutual way are being paid by the channel partner who opened the channel and not by the person who initiated the closing procedure.
+As both channel partners sign the on-chain transaction they have the chance to pay small fees for the Bitcoin transaction by using their on-chain fee estimator.
+Even though there is a potential waiting time, this type of channel close is usually faster than closing the bad way.
 
 ===== Examining the bad way - force close
 In case your node cannot engage in a mutual close (most likely because your channel partner is either offline or not responding) you will have to do a force close.


### PR DESCRIPTION
- closing tx, shutdown tx, etc:  to avoid any confusion I took the "shutdown tx" out and simply named it the "on-chain tx"
- replaced "party" with "channel partner" for consistency
- removed "as many people think". If the book does a good job, not many people will think that ! In any case, this phrase does not help. Better to just state the facts. 
- etc