### PR TITLE
multi: add skeleton chapter outlines 

### DIFF
--- a/channel-construction.asciidoc
+++ b/channel-construction.asciidoc
@@ -1,0 +1,37 @@
+Chapter overview:
+  * describes how channels are put together at the script+transaction level
+  * details how a channel if funded in the protocol
+  * details how a channel is updated in the protocol
+  * describes what needs to happen when a channel is force closed
+
+Relevant questions to answer:
+  * Channel construction:
+      * What's the difference between a replace-by-revocation based and a replace-by-versioning commitment format?
+      * What does the funding output script look like, what security guarantees does it give us?
+      * What's the difference between CSV and CLTV? How do both of these use the existing fields of the transaction to enforce new behavior?
+      * How do we implement revocation in our channel format?
+      * What does the script on the commitment to the broadcaster look like?
+      * What does the script on the commitment for the party that didn't broadcast look like?
+      * How are HTLCs constructed? What are second-level HTLCs?
+      * How has the commitment format in LN changed over time? What are some of the changes to the commitment format that've happened?
+  * Funding flow and messages:
+      * What are the messages exchanged to initiate a new channel with another peer?
+      * What do the parameters such as the max in flight do?
+      * How should the CSV values and the number of blocks until a channel is considered confirmed change with the size of the channel?
+      * What are wumbo channels? How are they enabled?
+      * What is an upfront shutdown address? What security does it offer?
+      * Is it possible to open multiple channels in a single transaction?
+  * Channel state machine:
+      * What does Medium Access Control mean in the context of network protocols?
+      * At a high level, how does the MAC protocol for 802.11 work?
+      * What steps need to happen for a new commitment state to be proposed and irrevocably committed for both parties?
+      * When is it safe for a party to forward a new HTLC to another peer? (may be out of scope for this chapter)
+      * Is it possible to commit a 
+      * How does the current MAC protocol for the LN work?
+        * What does an htlc_add message contain?
+        * How are HTLCs cancelled or settled?
+        * Can both parties propose updates at the same time?
+        * Is it possible for a party to add a batch of HTLCs in a single go?
+        * What constraints exist that both parties need to adhere to?
+      * How are fees paid in a channel? Who pays which fees? Has this changed with newer commitment formats?
+      * How would the MAC protocol need to change if we used channels with symmetric state?

--- a/channel-graph.asciidoc
+++ b/channel-graph.asciidoc
@@ -1,0 +1,21 @@
+Chapter overview:
+  * explains the channel graph, and how it's modified+verified
+
+Relevant questions to answer:
+  * Gossip announcements:
+      * How does a peer announce a new channel to the network?
+      * How do nodes verify a channel announcement? Why should they verify one in the first place?
+      * How does a node control _how_ a payment is routed through its channel?
+      * What knobs exist for a node to set in their channel updates?
+      * How often are channel updates sent?
+      * How does a node update its node in the channel graph? Do we we need to verify this?
+      * How quickly does an update propagate?
+      * What are "zombie" channels? Why do they matter?
+  * Channel graph syncing:
+      * What are the various ways a node can sync the channel graph?
+      * Which is the most efficient?
+      * What is the "gossip query" system?
+      * Does a node need to keep up with all gossip updates? Does this change if they're a routing node or mobile client?
+  * Protocol Extensions via Feature Bits and TLV:
+      * How can the channel graph be upgraded using feature bits and TLV fields?
+      * How does a receiver signal that they can accept MPP/AMP payments?

--- a/e2e-presentation-layer.asciidoc
+++ b/e2e-presentation-layer.asciidoc
@@ -1,0 +1,12 @@
+Chapter overview:
+  * presentation layer, applications, how payment details are exchanged
+
+Relevant questions to answer:
+  * What is BOLT 11?
+  * What information does an invoice contain?
+  * How can invoices be extended to integrate new protocol features?
+  * What are some unique things that can be done with LN?
+    * recurring payments
+    * donation addrs
+    * keysend
+    * custom data

--- a/onion-routing-htlc-forwarding.asciidoc
+++ b/onion-routing-htlc-forwarding.asciidoc
@@ -1,0 +1,21 @@
+Chapter overview:
+  * introduce multi-hop HTLC forwarding + onion routing at a lower level
+
+Relevant questions to answer:
+  * Onion Routing:
+    * What is onion routing? What security guarantees does it offer?
+    * What is the Sphinx format? How does it differ from prior mixnet packet formats?
+    * How does DH randomization work? (possibly too low-level)
+    * Why is it important to keep the packet fixed sized at all times?
+    * What routing information is contained in the payload for an node?
+    * How can the routing information be extended in the future?
+  * HTLC Forwarding:
+    * How does a node gain fees when it forwards a payment?
+    * What is the "cltv delta" why does it matter? 
+    * What does a successful HTLC forwarding look like?
+    * How can a node cancel back an HTLC off-chain?
+    * What is a typical network switch/hub? How can a similar analogy be applied to forwarding HTLCs?
+    * What is the circuit map, why does a node need to maintain this?
+    * Can fails or settles be safely pipelined on the network?
+    * How does a node send an error back to the sender without knowing who they are?
+    * What dangers exist w.r.t time-locks and timely on-chain confirmation?

--- a/p2p.asciidoc
+++ b/p2p.asciidoc
@@ -1,0 +1,26 @@
+Chapter overview:
+  * high level description of p2p interaction for the LN
+
+Relevant questions to answer:
+  * Encrypted P2P Transport:
+      * What is the noise protocol? How does it differ from TLS? Who created it
+      * and what are some of primary design principles?
+      * What is an authenticated key exchange?
+      * Why does Noise offer various handshakes? What are some of unique properties certain handshakes offer?
+      * What is key rotation in the context of a complete handshake? Why is it important?
+      * What is "brontide"? How is it used in LN today? How can it be upgraded in the future?
+  * LN Message Format:
+      * What kind of framing is used in the LN message format? What's the max message size and why is it in place?
+      * What is a varint? Why is it used in the protocol?
+      * What are the message types of some of the popular messages in the protocol?
+      * How can new messages be added in the future?
+  * Feature bits:
+      * What are feature bits in the network, and how+where are they advertised?
+      * How can feature bits be used to phase in new features to the protocol?
+      * Today, what are some of the major feature bits used in the system?
+      * What's the difference between and end-to-end network upgrade and an internal network upgrade? How's the analogous to the evolution of routers and protocols in the existing internet?
+  * TLV Message Extensions:
+      * What does TLV stand for?
+      * How is this related to the existing protobuf message format?
+      * Where are TLV fields used in the protocol today?
+      * How can TLV fields be used to extend the protocol, existing messages, and the onion itself?

--- a/p2p.asciidoc
+++ b/p2p.asciidoc
@@ -4,23 +4,41 @@ Chapter overview:
 Relevant questions to answer:
   * Encrypted P2P Transport:
       * What is the noise protocol? How does it differ from TLS? Who created it
+
       * and what are some of primary design principles?
+
       * What is an authenticated key exchange?
+
       * Why does Noise offer various handshakes? What are some of unique properties certain handshakes offer?
+
       * What is key rotation in the context of a complete handshake? Why is it important?
+
       * What is "brontide"? How is it used in LN today? How can it be upgraded in the future?
   * LN Message Format:
+
       * What kind of framing is used in the LN message format? What's the max message size and why is it in place?
+
       * What is a varint? Why is it used in the protocol?
+
       * What are the message types of some of the popular messages in the protocol?
+
       * How can new messages be added in the future?
   * Feature bits:
+
       * What are feature bits in the network, and how+where are they advertised?
+
       * How can feature bits be used to phase in new features to the protocol?
+
       * Today, what are some of the major feature bits used in the system?
+
       * What's the difference between and end-to-end network upgrade and an internal network upgrade? How's the analogous to the evolution of routers and protocols in the existing internet?
+
   * TLV Message Extensions:
+
       * What does TLV stand for?
+
       * How is this related to the existing protobuf message format?
+
       * Where are TLV fields used in the protocol today?
+
       * How can TLV fields be used to extend the protocol, existing messages, and the onion itself?

--- a/path-finding.asciidoc
+++ b/path-finding.asciidoc
@@ -1,0 +1,14 @@
+Chapter overview:
+  * How path finding works in the network
+
+Relevant questions to answer:
+  * What is packet switching? What is circuit switching? Which one does LN use today?
+  * In the abstract what is path finding?
+  * What is dijkstra's? What modifications need to be made to apply it to this domain?
+  * Why must path finding happen backwards (receiver to sender)?
+  * How is the information contained in a channel update used in path finding?
+  * How can errors sent during payment routing help the sender to narrow their search space?
+  * What is payment splitting? How does it work?
+  * What information can be sent to intermediate and the final node aside from the critical routing data?
+  * What are multi-hop locks? What addition privacy and security guarantees to they offer?
+  * How can the flexible onion space be used to enabled packet switching in the network?


### PR DESCRIPTION
In this PR, we add outlines for prospective chapters. As the final chapter structure/ordering isn't finalized, they don't include an explicit chapter number. Each chapter outline includes a high level overview, as well as a series of questions that the reader should be able to answer after reading the chapter. These questions are also meant to server as a guide to prospective contributors as well. Some of the questions posted have already been answered in existing chapters checked into the repo. 