### PR TITLE
Fix 'loose' vs 'lose' mistakes

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -195,7 +195,7 @@ With the modification, Bob can now detect the fraud and he is enabled to punish 
 Bob ends up with 10 mBTC gaining 7 mBTC for catching Alice cheat. 
 Alice ends up with 0 mBTC. 
 For cheating she lost the 7 mBTC she still had. 
-With such a strong penalty mechanism in place Alice will not be tempted to cheat by publishing an old state as she would almost always loose all her remaining funds in the channel.
+With such a strong penalty mechanism in place Alice will not be tempted to cheat by publishing an old state as she would almost always lose all her remaining funds in the channel.
 
 [Note]
 ====
@@ -314,7 +314,7 @@ In this case the fees of the commitment transaction are again paid by the partne
 Also all the routing attempts will have to be resolved just as explained during the "force close". 
 The "ugly way" can be executed faster than the "good" and the "bad way" to close a channel. 
 
-Game theory predicts that cheating is not a successful strategy because it is easy to detect a cheater and as penalty the cheater will loose all funds. 
+Game theory predicts that cheating is not a successful strategy because it is easy to detect a cheater and as penalty the cheater will lose all funds. 
 Hence, we do not recommend to attempt to cheat. We do, however, recommend that anyone catching a cheater punish him to the fullest by taking his funds.
 
 === Invoices

--- a/routing.asciidoc
+++ b/routing.asciidoc
@@ -4,7 +4,7 @@ In this section you will finally understand how payment channels can be connecte
 This allows our gamer Gloria to receive funds from her viewers without being required to maintain a separate channel with every of her viewers who want to tip her.
 As long as there exists a path of well funded payment channels from a fan to Gloria she will be able to receive money.
 Despite the fact that the nodes along the path forward the money to Gloria they are not able to steal the money and run with it.
-Similarly, they cannot loose money while participating in the routing process.
+Similarly, they cannot lose money while participating in the routing process.
 They are however entitled to charge a routing fee for their service.
 In particular due to the used Onion routing intermediary nodes will not know who is the initiator of the payment and who is the final recipient. 
 Being able to connect payment channels yields the main value proposition behind the lightning network.
@@ -90,7 +90,7 @@ Now Bob repeats the process by fulfilling the contract between Alice and him wit
 
 With such a chain of contracts Bob and Wei have not been able to run with the money as they actually deposied money first.
 However if Gloria or anyone along this chain does not release the secrete preimage everone has already send golden coins to their escrow service but will never get reimbursed.
-So while noone could steal money from Alice everyone could still loose money.
+So while noone could steal money from Alice everyone could still lose money.
 This is obviously not desireable.
 Luckily this can be resolved by including a deadline to the contract.
 Reaching the deadline the contract has to be fulfilled or otherwise it would be invalidated and the escrow service would return the money to the person who made the original deposit.
@@ -288,7 +288,7 @@ image:images/routing-setup-htlc-4.png[]
 This process is completely symmetrical to the one where Alice sent her signatures for Bob's new commitment transaction.
 Now Alice is the one having two valid commitment transactions.
 Technically she can still abort the payment by publishing her old commitment transaction to the bitcon network.
-Noone would loose anything as Bob knows that the contract is still being set up and not fully set up yet.
+Noone would lose anything as Bob knows that the contract is still being set up and not fully set up yet.
 This is a little bit different than how the situation would look like in a real world scenario.
 Recall Alice and Bob both have set up a new commitment transaction and have exchanged signatures.
 In the real world one would argue that this contract is now valid.


### PR DESCRIPTION
Saw a place where it says "loose" when it should be "lose".  Searched through the project to find other places with the same mistake and fixed them.