### PR TITLE
removed an extra 'the' in this sentence

### DIFF
--- a/01_introduction.asciidoc
+++ b/01_introduction.asciidoc
@@ -18,7 +18,7 @@ Because blockchains are gossip protocols, each node is required to know and vali
 
 [NOTE]
 ====
-The side effects of increasing the block size or the decreasing the block time with respect to centralization of the network are severe as a few calculations with the numbers show. 
+The side effects of increasing the block size or decreasing the block time with respect to centralization of the network are severe as a few calculations with the numbers show. 
 Let us assume the usage of Bitcoin grows so that the network has to process 40,000 transactions per second.
 Assuming 250 Bytes on average per transaction this would result in a data stream of 10 Megabyte per second or 80 Mbit/s just to be able to receive all the transactions.
 This does not include the traffic overhead of forwarding the transaction information to other peers.


### PR DESCRIPTION
Cleaned up an unnecessary 'the' in the first [note] block in the introduction.