### PR TITLE
ch01: Acronym LN (mostly) removed

### DIFF
--- a/01_introduction.asciidoc
+++ b/01_introduction.asciidoc
@@ -2,13 +2,13 @@
 [[intro_what_is_the_lightning_network]]
 == Introduction
 
-Welcome to Mastering the Lightning Network (LN)!
+Welcome to Mastering the Lightning Network!
 
-The Lightning Network is a protocol for using Bitcoin in a smart and non-obvious way.
+The Lightning Network, abbreviated with LN, is a protocol for using Bitcoin in a smart and non-obvious way.
 Thus it is a second layer technology on top of Bitcoin.
-It is changing the way people exchange value online and it's one of the most exciting advancements to happen to the Bitcoin network over the past few years. Right now, LN is in its infancy. In concept it's about 5 years old, in implementation about 3 years old. We're only beginning to see the opportunities LN provides including improved privacy, speed, and scale. With core knowledge of LN, you can help shape the future of the network while building opportunities for yourself as well. Some basic knowledge about Bitcoin is assumed but can be readily acquired by reading the first two chapters of _Mastering Bitcoin_ which are available for free online.
+It is changing the way people exchange value online and it's one of the most exciting advancements to happen to the Bitcoin network over the past few years. Right now, the Lightning Network is in its infancy. In concept it's about 5 years old, in implementation about 3 years old. We're only beginning to see the opportunities the Lightning Network provides including improved privacy, speed, and scale. With core knowledge of the Lightning Network, you can help shape the future of the network while building opportunities for yourself as well. Some basic knowledge about Bitcoin is assumed but can be readily acquired by reading the first two chapters of _Mastering Bitcoin_ which are available for free online.
 
-While the bulk of this book is written for programmers, the first two chapters are written to be approachable by anyone regardless of technical experience. In order to better understand how the technology actually works, and why people use it, we'll be following a number of users and their stories. But first, we'll introduce some of the key concepts in LN. Let's get started with why the Lightning Network was proposed in the first place.
+While the bulk of this book is written for programmers, the first two chapters are written to be approachable by anyone regardless of technical experience. In order to better understand how the technology actually works, and why people use it, we'll be following a number of users and their stories. But first, we'll introduce some of the key concepts in the Lightning Network. Let's get started with why the Lightning Network was proposed in the first place.
 
 === Motivation for the Lightning Network
 
@@ -104,4 +104,4 @@ Wei is an entrepreneur who sells information services related to the Lightning N
 
 === Chapter Summary
 
-In this chapter we looked at the history of the Lightning Network and the motivations behind second layer scaling solutions for Bitcoin and other blockchain based networks. We learned basic terminology including node, payment channel, on-chain transactions, and off-chain payments. Finally, we met Alice, Bob, Saanvi, John, Gloria, Farel, and Wei who we'll be following throughout the rest of the book. In the next chapter we'll meet Alice and walk through her thought process as she selects a Lightning wallet and prepares to make her first LN payment to buy a cup of coffee from Bob's Cafe.
+In this chapter we looked at the history of the Lightning Network and the motivations behind second layer scaling solutions for Bitcoin and other blockchain based networks. We learned basic terminology including node, payment channel, on-chain transactions, and off-chain payments. Finally, we met Alice, Bob, Saanvi, John, Gloria, Farel, and Wei who we'll be following throughout the rest of the book. In the next chapter we'll meet Alice and walk through her thought process as she selects a Lightning wallet and prepares to make her first Lightning payment to buy a cup of coffee from Bob's Cafe.


### PR DESCRIPTION
- I removed acronym from first sentence and put it into the second. I did not feel that it is a good start when the first sentence of the book already has an acronym.
- Removed LN acronym 4-5 times further down. It was not consistently used anyway. Sometimes yes, sometimes no. I also think it reads better spelled out. So, for a book I feel it is better to spell it out 4 times, than to abbreviate it 4 times.