### PR TITLE
glossary: "oldid" removed from Wikipedia URL links

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -37,7 +37,7 @@ Asymmetric Cryptographic System::
     Asymmetric cryptography, or public-key cryptography, is a cryptographic system that uses pairs of keys: public keys which may be disseminated widely, and private keys which are known only to the owner.
     The generation of such keys depends on cryptographic algorithms based on mathematical problems to produce one-way functions.
     Effective security only requires keeping the private key private; the public key can be openly distributed without compromising security.
-    https://en.wikipedia.org/w/index.php?title=Public-key_cryptography&oldid=877579180
+    https://en.wikipedia.org/w/index.php?title=Public-key_cryptography
 
 Autopilot::
     The autopilot is a recommendation engine for Lightning Network nodes that uses statistics of the known topology to suggest which nodes they should open channels with.
@@ -146,13 +146,13 @@ Diffie Hellman Key Exchange::
     This shared secret may be directly used as a key, or to derive another key.
     The key, or the derived key, can then be used to encrypt subsequent communications using a symmetric-key cipher.
     An example of the derived key would be the shared secrete between the ephemeral session key of a sender of an onion with the nodes public key of a hop of the onion as described and used by the SPHINX Mix Format.
-    Via https://en.wikipedia.org/w/index.php?title=Elliptic-curve_Diffie%E2%80%93Hellman&oldid=836070673
+    Via https://en.wikipedia.org/w/index.php?title=Elliptic-curve_Diffie%E2%80%93Hellman
 
 Digital Signature::
     A digital signature is a mathematical scheme for verifying the authenticity of digital messages or documents.
     A valid digital signature gives a recipient reason to believe that the message was created by a known sender, that the sender cannot deny having sent the message, and that the message was not altered in transit.
     They can be seen as cryptographic commitments in which the message is not hidden.
-    https://en.wikipedia.org/w/index.php?title=Digital_signature&oldid=876680165
+    https://en.wikipedia.org/w/index.php?title=Digital_signature
 
 double-spending::
     Double-spending is the result of successfully spending some money more than once.
@@ -223,7 +223,7 @@ Hash Function::
     It is infeasible to generate a message from its hash value except by trying all possible messages.
     A small change to a message should change the hash value so extensively that the new hash value appears uncorrelated with the old hash value.
     It is infeasible to find two different messages with the same hash value.
-    https://en.wikipedia.org/w/index.php?title=Cryptographic_hash_function&oldid=868055371
+    https://en.wikipedia.org/w/index.php?title=Cryptographic_hash_function
 
 hashlocks::
     A hashlock is a type of encumbrance that restricts the spending of an output until a specified piece of data is publicly revealed. Hashlocks have the useful property that once any hashlock is opened publicly, any other hashlock secured using the same key can also be opened. This makes it possible to create multiple outputs that are all encumbered by the same hashlock and which all become spendable at the same time.
@@ -289,7 +289,7 @@ Onion Routing::
     When the final layer is decrypted, the message arrives at its destination.
     The sender remains anonymous because each intermediary knows only the location of the immediately preceding and following nodes.
     With the SPHINX Mix Format, the final destination also remains anonymous as only the previous router could see it but does not know if they are routing it to the final node or just the next hop.
-    https://en.wikipedia.org/w/index.php?title=Onion_routing&oldid=870849217
+    https://en.wikipedia.org/w/index.php?title=Onion_routing
 
 output::
     Output, transaction output, or TxOut is an output in a transaction which contains two fields: a value field for transferring zero or more satoshis and a pubkey script for indicating what conditions must be fulfilled for those satoshis to be further spent.


### PR DESCRIPTION
This was already mentioned in PR #256 

@renepickhardt commented the following there: 
  > the oldid REST links where there on purpose because they fix the version 
  > that I have read at the time of citing the article. 
  > We should have a general decision how we want to quote wikipedia links
  @Roasbeef @aantonop

IMHO: I would remove oldid-s assuming that pages get better over time.