### PR TITLE
ch02: global replacement of "LN Wallet" with "Lightning Wallet"

### DIFF
--- a/02_getting_started.asciidoc
+++ b/02_getting_started.asciidoc
@@ -80,7 +80,7 @@ In <<lnwallet-examples>> we see some examples of currently popular Lightning nod
 
 // TODO: Add a lot more wallet/node examples, confirm the details for correctness
 [[lnwallet-examples]]
-.Examples of Popular LN Wallets
+.Examples of Popular Lightning Wallets
 [options="header"]
 |===
 | Application    | Device  | LN Node     | Bitcoin Node          | Keystore
@@ -102,13 +102,13 @@ When selecting a wallet, keep in mind that even if you don't see these trade-off
 
 In the next section, we will return to our first user and walk through her first Lightning wallet setup. She has chosen a wallet that is more sophisticated than the easier custodial wallets. This allows us to show some of the underlying complexity and introduce some of the inner workings of an advanced wallet during our example. You may find that your first ideal wallet is further towards "ease of use", by accepting some of the control and privacy trade-offs. Or perhaps you are more of a "power user" and want to run your own LN and Bitcoin nodes as part of your wallet solution.
 
-=== Alice's First LN Wallet
+=== Alice's First Lightning Wallet
 
 Alice is a long time Bitcoin user. We first met Alice in Chapter 1 of _"Mastering Bitcoin"_ footnote:["Mastering Bitcoin 2nd Edition, Chapter 1" Andreas M. Antonopoulos (https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch01.asciidoc).], when she bought a cup of coffee from Bob's cafe using a bitcoin transaction. Now, Alice is eager to learn about and experiment with the Lightning Network. First, she has to select a Lightning wallet that meets her needs.
 
 Alice does not want to entrust custody of her bitcoin to third parties. She has learned enough about cryptocurrency to know how to use a wallet. She also wants a mobile wallet so that she can use it for small payments on-the-go, so she chooses the _Eclair_ wallet, a popular non-custodial mobile Lightning wallet.
 
-==== Downloading and Installing a LN Wallet
+==== Downloading and Installing a Lightning Wallet
 
 When looking for a new cryptocurrency wallet, you must be very careful to select a secure source for the software.
 


### PR DESCRIPTION
- see also Issue #175 
- 3 occurrences replaced
- "Lightning Wallet seems to be the more appropriate term and we should be consistent about it.
- I also checked ch01 and ch03, but no occurrences there