### PR TITLE
ch03: replaced "LN" with "Lightning Network" exactly one

### DIFF
--- a/03_how_ln_works.asciidoc
+++ b/03_how_ln_works.asciidoc
@@ -57,7 +57,7 @@ Besides all the technical primitives, the Lightning Network protocol is a creati
 
 === Payment channels
 
-As you have seen in the last chapter, in order to use the Lightning Network, Alice had to use her wallet software to create a payment channel with another LN participant.
+As you have seen in the last chapter, in order to use the Lightning Network, Alice had to use her wallet software to create a payment channel with another Lightning Network participant.
 From a computer science perspective a payment channel is a cryptographic communication protocol between you and your channel partner.
 It allows both of the channel partners to send funds back and forth as often as they wish.
 A channel is only limited by two things:


### PR DESCRIPTION
- Acronym "LN" shows up 3 time in chapter 3
- Twice explained (the definition): these I left in, because further chapters will/might make use of the acronym
- The third occurrence I replaced, as it adds just 1 work to the book, increases readability, is inconsistent with rest of this chapter