### PR TITLE
ch02: global replacement of "LN Node" with "Lightning Node"

### DIFF
--- a/02_getting_started.asciidoc
+++ b/02_getting_started.asciidoc
@@ -39,7 +39,7 @@ Finally, those seeking simplicity and convenience, even at the expense of contro
 There are many ways wallets can be characterized or categorized. 
 The most important questions to ask about a specific wallet are:
 
-- Does this Lightning wallet have a full LN Node or does it use a third-party LN Node?
+- Does this Lightning wallet have a full Lightning Node or does it use a third-party Lightning Node?
 - Does this Lightning wallet have a full Bitcoin Node or does it use a third-party Bitcoin Node? footnote:[If a Lightning wallet uses a third-party Lightning node, it is this third-party Lightning node who decides how to communicate with Bitcoin. Hence, using a third-party Lightning node implies that you as a wallet user also use a third-party Bitcoin node. Only in the other case, when the Lightning wallet uses its own Lightning node, does the choice "full Bitcoin-node" vs. "thrid-party Bitcoin node" exist. ]
 - Does this Lightning wallet store its own keys under user control (self-custody) or are the keys held be a third-party custodian?
 
@@ -52,19 +52,19 @@ But remember that this is just one way of categorizing Lightning wallets.
 .Lightning Wallets Quadrant
 [options="header"]
 |===
-|                        | *Full LN Node*      | *3rd-party LN Node*    
+|                        | *Full Lightning Node*      | *3rd-party Lightning Node*    
 | *Self-Custody*         | Q1: High technical skill, least trust in 3rd parties, most permissionless | Q2: Below medium technical skills, below medium trust in 3rd parties, requires some permissions 
 | *Custodial*            | Q3: Above medium technical skills, above medium trust in 3rd parties, requires some permissions | Q4: Low technical skills, high trust in 3rd parties, least permissionless 
 |===
 
-Q3, quadrant 3, where a full LN node is used but the keys are held by a custodian is currently not common. 
+Q3, quadrant 3, where a full Lightning node is used but the keys are held by a custodian is currently not common. 
 Future wallets from that quadrant would let a user worry about the operational aspects of their node, but then delegate the access to the keys to a third party which may use primarily cold storage.
 
 Lightning wallets can be installed on a variety of devices, including laptops, servers, and mobile devices. To run a full Lightning node (one that participates in "gossip" and creates its own map of the network for path finding and routing) you will need to use a server or desktop computer, as mobile devices and laptops are usually not powerful enough in terms of capacity, processing, battery life, and connectivity.
 
 The category "Third-party Lightning Nodes" can again be subdivided into:
 
-- Lightweight: means that the Lightning Node is operated by a third party and that the wallet obtains the required information through an API that connects wallet and third-party LN node.
+- Lightweight: means that the Lightning Node is operated by a third party and that the wallet obtains the required information through an API that connects wallet and third-party Lightning node.
 - None: means that not only is the Lightning Node operated by a third party but most of the wallet is operated by a third party in the cloud such that the wallet does not even need to make calls on a Lightning node API.
 
 These subcategories are used in Table <<lnwallet-examples>>.
@@ -83,7 +83,7 @@ In <<lnwallet-examples>> we see some examples of currently popular Lightning nod
 .Examples of Popular LN Wallets
 [options="header"]
 |===
-| Application    | Device  | LN Node     | Bitcoin Node          | Keystore
+| Application    | Device  | Lightning Node | Bitcoin Node          | Keystore
 | lnd            | Server  | Full Node   | Bitcoin Core/btcd     | Self-Custody
 | c-lightning    | Server  | Full Node   | Bitcoin Core          | Self-Custody
 | Eclair Server  | Server  | Full Node   | Bitcoin Core/Electrum | Self-Custody


### PR DESCRIPTION
- see also Issue #174 
- see also Issue #175 
- it is also "Bitcoin Node", not "Bitcoin Network Node"
- simpler is better, shorter is better
- 7 occurrences were replaced