### PR TITLE
ch02: global replacement of "LN Channel" with "Lightning Channel"

### DIFF
--- a/02_getting_started.asciidoc
+++ b/02_getting_started.asciidoc
@@ -282,19 +282,19 @@ While Alice could select a specific Lightning node, or use the "Random node" opt
 
 Choosing the ACINQ node will slightly reduce Alice's privacy, as it will give ACINQ the ability to see all of Alice's transactions. It will also create a Single Point of Failure, since Alice will only have one channel, and if the ACINQ node is not available, Alice will not be able to make payments. To keep things simple at first, we will accept these trade-offs. In subsequent chapters we will gradually learn how to gain more independence and make fewer trade-offs!
 
-Alice selects "ACINQ Node" and is ready to open her first LN channel.
+Alice selects "ACINQ Node" and is ready to open her first channel on the Lightning network.
 
-==== Opening a LN Channel
+==== Opening a Lightning Channel
 
 When Alice selects a node to open a new channel, she is asked to select how much bitcoin she wants to allocate to this channel. In subsequent chapters, we will discuss the implications of these choices, but for now, Alice will allocate almost all her funds to the channel. Since she will have to pay transaction fees to open the channel, she will select an amount a few dollars (or a few thousandths of a bitcoin) less than her total balance.
 
 Alice allocates 0.018BTC of her 0.020 total to her channel and accepts the default fee rate, as shown in <<eclair-open-channel>>.
 
 [[eclair-open-channel]]
-.Opening a LN Channel
+.Opening a Lightning Channel
 image:images/eclair-open-channel-detail.png[]
 
-Once she clicks "OPEN", her wallet constructs the special Bitcoin transaction that opens a LN channel, known as the _funding transaction_. The "on-chain" funding transaction is sent to the Bitcoin Network for confirmation.
+Once she clicks "OPEN", her wallet constructs the special Bitcoin transaction that opens a Lightning channel, known as the _funding transaction_. The "on-chain" funding transaction is sent to the Bitcoin Network for confirmation.
 
 Alice now has to wait again (see <<eclair-channel-waiting>>) for the transaction to be recorded on the Bitcoin blockchain. As with the initial Bitcoin transaction that she used to acquire her bitcoin, she has to wait for six or more confirmations (approximately one hour).
 
@@ -360,4 +360,4 @@ Alice presses "PAY," and a second later, Bob's tablet shows a successful payment
 
 === Conclusion
 
-In this chapter, we followed Alice as she downloaded and installed her first Lightning wallet, acquired and transferred some bitcoin, opened her first LN channel, and bought a cup of coffee by making her first payment on the Lightning Network. In the following chapters, we will look "under the covers" at how each component in the Lightning Network works, and how Alice's payment reached Bob's Cafe.
+In this chapter, we followed Alice as she downloaded and installed her first Lightning wallet, acquired and transferred some bitcoin, opened her first Lightning channel, and bought a cup of coffee by making her first payment on the Lightning Network. In the following chapters, we will look "under the covers" at how each component in the Lightning Network works, and how Alice's payment reached Bob's Cafe.


### PR DESCRIPTION
- see similar PR #268 
- 5 occurrences
- wallets already use the term "Lightning Channel" (instead of Lightning Network Channel)
- see 3 image of mobile wallet used in this book, all 3 images have term "Lightning Channel"