### PR TITLE
ch02: global replacement of "LN Invoice" with "Lightning Invoice"

### DIFF
--- a/02_getting_started.asciidoc
+++ b/02_getting_started.asciidoc
@@ -340,7 +340,7 @@ image:images/bob-cafe-posapp.png[]
 Alice selects the "Cafe Latte" option from the screen and is presented with a _Lightning Invoice_ as shown in <<bob-cafe-invoice>>
 
 [[bob-cafe-invoice]]
-.LN Invoice for Alice's latte
+.Lightning Invoice for Alice's latte
 image:images/bob-cafe-invoice.png[]
 
 To pay the invoice, Alice opens her Eclair wallet and selects the "Send" button (which looks like a right-facing arrow) under the "TRANSACTION HISTORY" tab, as shown in <<alice-send-start>>.


### PR DESCRIPTION
- similar to PR #268 and PR #269 
- issues #174 and #175 
- 1 occurrence only 
- "Lightning Invoice" was already used in text, this fixes also the inconsistency