### PR TITLE
tiny English improvements 3

### DIFF
--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -32,11 +32,11 @@ To keep things consistent, we use the +bash+ shell in all command-line examples.
 
 ==== Donwloading the book repository
 
-All the code examples are available in the book's repository. The repository will be kept up-to-date, as much as possible, so you should always look for the latest version in the repository, instead of copying it from the printed book or ebook version of this test.
+All the code examples are available in the book's online repository. Because the repository will be kept up-to-date as much as possible, you should always look for the latest version in the online repository, instead of copying it from the printed book or the ebook.
 
-You can download the repository as a ZIP bundle by visiting +github.com/lnbook/lnbook+ and selecting the "Clone or Download" green button on the right.
+You can download the repository as a ZIP bundle by visiting +github.com/lnbook/lnbook+ and selecting the green "Clone or Download" button on the right.
 
-Alternatively, you can use the +git+ command, to create a version-controlled clone of the repository on your local computer. Git is a distributed version control system that is used by most developers to collaborate on software development and track changes to software repositories. Donwload and install +git+ by following the instructions on https://git-scm.com/.
+Alternatively, you can use the +git+ command to create a version-controlled clone of the repository on your local computer. Git is a distributed version control system that is used by most developers to collaborate on software development and track changes to software repositories. Donwload and install +git+ by following the instructions on https://git-scm.com/.
 
 
 To make a local copy of the repository on your computer, run the git command as follows:


### PR DESCRIPTION
- putting emphasis on repository being online
- "the" article required in this case
- removed "version" from "ebook version" to simplify
- green: work order corrected
- no comma with "..., to"