### PR TITLE
code, spelling and grammar fixes for node_client chapter

### DIFF
--- a/code/docker/setup-channels.sh
+++ b/code/docker/setup-channels.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 echo Getting node IDs
-alice_address=$(docker-compose exec -T Alice lncli -n regtest getinfo | jq .identity_pubkey)
-bob_address=$(docker-compose exec -T Bob lightning-cli getinfo | jq .id)
-wei_address=$(docker-compose exec -T Wei eclair-cli -s -j -p eclair getinfo| jq .nodeId)
-gloria_address=$(docker-compose exec -T Gloria lncli -n regtest getinfo | jq .identity_pubkey)
+alice_address=$(docker-compose exec -T Alice bash -c "lncli -n regtest getinfo | jq .identity_pubkey")
+bob_address=$(docker-compose exec -T Bob bash -c "lightning-cli getinfo | jq .id")
+wei_address=$(docker-compose exec -T Wei bash -c "eclair-cli -s -j -p eclair getinfo| jq .nodeId")
+gloria_address=$(docker-compose exec -T Gloria bash -c "lncli -n regtest getinfo | jq .identity_pubkey")
 
 # The jq command returns JSON strings enclosed in double-quote characters
 # These will confuse the shell later, because double-quotes have special
@@ -40,7 +40,7 @@ docker-compose exec -T Wei eclair-cli -p eclair connect --uri=${gloria_address}@
 docker-compose exec -T Wei eclair-cli -p eclair open --nodeId=${gloria_address} --fundingSatoshis=1000000
 
 echo Get 10k sats invoice from Gloria
-gloria_invoice=$(docker-compose exec -T Gloria lncli -n regtest addinvoice 10000 | jq .payment_request )
+gloria_invoice=$(docker-compose exec -T Gloria bash -c "lncli -n regtest addinvoice 10000 | jq .payment_request")
 
 # Remove quotes
 gloria_invoice=${gloria_invoice//\"}

--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -492,6 +492,7 @@ We now have a copy of c-lightning, cloned into the +lightning+ subfolder, and we
 ==== Compiling the c-lightning source code
 
 Next, we use a set of _build scripts_ that are commonly available on many open source projects. These are +configure+ and +make+, and they allow us to:
+
 * Select the build options and check necessary dependencies (+configure+).
 * Build and install the executables and libraries (+make+).
 
@@ -625,7 +626,7 @@ As before, we start the bitcoind container in one terminal and LND in another. I
 $ docker run -it --network lnbook --name bitcoind lnbook/bitcoind
 ----
 
-Next, we start the LND container we just build. We will need to attach it to the +lnbook+ network and give it a name, just as we did with the other containers:
+Next, we start the LND container we just built. We will need to attach it to the +lnbook+ network and give it a name, just as we did with the other containers:
 
 ----
 $ docker run -it --network lnbook --name lnd lnbook/lnd
@@ -783,7 +784,7 @@ As before, we start the bitcoind container in one terminal and the eclair contai
 $ docker run -it --network lnbook --name bitcoind lnbook/bitcoind
 ----
 
-Next, we start the eclair container we just build. We will need to attach it to the +lnbook+ network and give it a name, just as we did with the other containers:
+Next, we start the eclair container we just built. We will need to attach it to the +lnbook+ network and give it a name, just as we did with the other containers:
 
 ----
 $ docker run -it --network lnbook --name eclair lnbook/eclair
@@ -912,7 +913,7 @@ Congratulations, you have built Eclair from source and you are ready to code, te
 
 === Building a complete network of diverse Lightning Nodes
 
-Our final example, in this section, will bring together all the various containers we have build to form a Lightning network made of diverse (LND, c-lightning, Eclair) node implementations. We will compose the network by connecting the nodes together, opening channels from one node to another, and finally, by routing a payment across these channels.
+Our final example, in this section, will bring together all the various containers we have built to form a Lightning network made of diverse (LND, c-lightning, Eclair) node implementations. We will compose the network by connecting the nodes together, opening channels from one node to another, and finally, by routing a payment across these channels.
 
 In this example, we will replicate the Lighting network example from <<routing_on_a_network_of_payment_channels>>. Specifically, we will create four Lightning nodes named Alice, Bob, Wei and Gloria. We will connect Alice to Bob, Bob to Wei, and Wei to Gloria. Finally, we will have Gloria create an invoice and have Alice pay that invoice. Since Alice and Gloria are not directly connected, the payment will be routed as an HTLC across all the payment channels.
 
@@ -1005,7 +1006,7 @@ $ docker-compose logs -f Alice
 
 Our Lightning network should now be running. As we saw in the previous sections of this chapter, we can issue commands to a running docker container with the +docker exec+ command. Regardless of whether we started the container with +docker run+ or started a bunch of them with +docker-compose up+, we can still access containers individually using the docker commands.
 
-To make things easier, we have a little helper script that sets up the network, issues the invoice and makes the payment. The script is called +setup-channels.sh+ and is a Bash shell script. Keep in mind, this script is not very sophisticated! It "blindly" throws commands at the various nodes and doesn't do any error checking. If the network is running correct and the nodes are funded, then it all works nicely. But, you have to wait a bit for everything to boot up and for the network to mine a few blocks and settle down. This usually takes 1-3 minutes. Once you see the block height at 102 or above on each of the nodes, you are ready. If the script fails, you can stop everything (+docker-compose down+) and try again from the beginning, or you can manually issue the commands in the script one by one and look at the results.
+To make things easier, we have a little helper script that sets up the network, issues the invoice and makes the payment. The script is called +setup-channels.sh+ and is a Bash shell script. Keep in mind, this script is not very sophisticated! It "blindly" throws commands at the various nodes and doesn't do any error checking. If the network is running correctly and the nodes are funded, then it all works nicely. But, you have to wait a bit for everything to boot up and for the network to mine a few blocks and settle down. This usually takes 1-3 minutes. Once you see the block height at 102 or above on each of the nodes, you are ready. If the script fails, you can stop everything (+docker-compose down+) and try again from the beginning, or you can manually issue the commands in the script one by one and look at the results.
 
 [TIP]
 ====

--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -447,7 +447,8 @@ Reading package lists... Done
 
 $ sudo apt-get install -y \
   autoconf automake build-essential git libtool libgmp-dev \
-  libsqlite3-dev python python3 python3-mako net-tools zlib1g-dev \ libsodium-dev gettext
+  libsqlite3-dev python python3 python3-mako net-tools zlib1g-dev \
+  libsodium-dev gettext
 
 Reading package lists... Done
 Building dependency tree

--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -849,7 +849,7 @@ Check that you have the correct version installed and ready to use by running:
 ----
 $ javac -version
 javac 11.0.7
-$ mvn -V
+$ mvn -v
 Apache Maven 3.6.1
 Maven home: /usr/share/maven
 Java version: 11.0.7, vendor: Ubuntu, runtime: /usr/lib/jvm/java-11-openjdk-amd64

--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -295,7 +295,7 @@ As you can see, we need to tell +bitcoin-cli+ where the bitcoind data directory 
 All the docker containers also have +jq+ installed, which is a command-line JSON encoder/decoder, to help us process JSON on the command-line or from inside scripts. You can send the JSON output of any command to +jq+ using the +|+ character ("pipe" notation). For example, if we pipe the +getblockchaininfo+ JSON result we got above, we can extract the specific field +blocks+ like this:
 
 ----
-$ docker exec bitcoind bitcoin-cli -datadir=/bitcoind getblockchaininfo | jq .blocks
+$ docker exec bitcoind bash -c "bitcoin-cli -datadir=/bitcoind getblockchaininfo | jq .blocks"
 189
 ----
 


### PR DESCRIPTION
- Existing code assumes jq is installed on the local machine. To run jq inside docker use the 'bash -c' flag with double quotes.
- missing newline char causes apt-get install command to fail when installing c-lightning pre-req libraries
- github does not display markdown lists correctly unless list items are preceded by an empty line
- 'build' -> 'built' in several places in the text
- when building eclair wallet, 'mvn -V' is an invalid argument, leading to scary build failure messages. Instead use 'mvn -v'
- 'If the network is running correct' -> 'If the network is running correctly'