### PR TITLE
Node Operations - Submarine Swap

### DIFF
--- a/node_operations.asciidoc
+++ b/node_operations.asciidoc
@@ -504,6 +504,16 @@ Another technique you can use involves running a second Lightning node that is n
 
 ===== Loop-out sweep
 
+==== Submarine Swap
+
+Submarine swaps, conceptualized by co-author Olaoluwa Osuntokun and Alex Bosworth, allow on-chain Bitcoin to be exchanged for Lightning Bitcoin and vice versa.
+The user could initiate a submarine swap and send all available Lightning Bitcoin to the other party, who will then send them on-chain Bitcoin in exchange.
+The on-chain Bitcoin could even be sent to a different wallet entirely.
+The user has then successfully "sweeped" their Bitcoin off of the Lightning Network and is left with the minimum amount of satoshis in the channel required as a reserve and an open channel with inbound capacity.
+
+In the future this could be a paid service offered by other Nodes on the Lightning Network which advertise exchange rates for the conversion.
+
+
 ==== Watchtowers
 
 


### PR DESCRIPTION
Added Submarine Swap as another example for sweeping funds out of a Lightning Channel