### PR TITLE
node_operations: English, touch ups, BTCPay, Raspi

### DIFF
--- a/node_operations.asciidoc
+++ b/node_operations.asciidoc
@@ -106,7 +106,7 @@ Installing a Lightning node (or also a Bitcoin node), may be daunting if you are
 
 ==== RaspiBlitz
 
-One of the most popular and complete such "helpers", is _RaspiBlitz_, a project built by Christian Rootzoll, which is intended to be installed on a Raspberry Pi 4. RaspiBlitz comes with a recommended hardware "kit" that you can build in a matter of hours, or at most a weekend. If you attend a Lightning "hackathon" in your city, you are likely to see many people working on their RaspiBlitz set up, swapping tips and helping each other. You can find the RaspiBlitz project here:
+One of the most popular and complete "helper" is _RaspiBlitz_, a project built by Christian Rootzoll. It is intended to be installed on a Raspberry Pi 4. RaspiBlitz comes with a recommended hardware "kit" that you can build in a matter of hours or at most a weekend. If you attend a Lightning "hackathon" in your city, you are likely to see many people working on their RaspiBlitz setup, swapping tips, and helping each other. You can find the RaspiBlitz project here:
 
 https://github.com/rootzoll/raspiblitz
 
@@ -119,7 +119,7 @@ In addition to a Bitcoin and Lightning node, RaspiBlitz can install a number of 
 * BTCPayServer (Cryptocurrency Payment Processor)
 * BTC-RPC-Explorer (Bitcoin Blockchain Explorer)
 * LNbits (Lightning wallet/accounts System)
-* SpecterDesktop (Multisig Trezor, Ledger, COLDCARDwallet & Specter-DIY)
+* SpecterDesktop (Multisig Trezor, Ledger, Coldcard Wallet & Specter-DIY)
 * LNDmanage (Advanced Channel Management CLI)
 * Loop (Submarine Swaps Service)
 * JoinMarket (CoinJoin Service)
@@ -127,7 +127,7 @@ In addition to a Bitcoin and Lightning node, RaspiBlitz can install a number of 
 
 ==== MyNode
 
-MyNode is another popular open source project including a lot of Bitcoin related software. Is is easy to install: you "flash" the installer onto an SD card, and boot your mini-PC from the SD card. You do not need any screen to use myNode as the administrative tools are accessible from a browser. You can manage it from a computer or even from your smartphone. Once installed, go to http://mynode.local/ and create a lightning wallet and node in two clicks.
+_MyNode_ is another popular open source "helper" project including a lot of Bitcoin related software. Is is easy to install: you "flash" the installer onto an SD card and boot your mini-PC from the SD card. You do not need any monitor to use myNode as the administrative tools are accessible remotely from a browser. If your mini-PC has no monitor, mouse, or keyboard, you can manage it from another computer or even from your smartphone. Once installed, go to http://mynode.local/ and create a Lightning wallet and node in two clicks.
 
 You can find the MyNode project here:
 
@@ -142,26 +142,27 @@ In addition to a Bitcoin and Lightning node, MyNode can optionally install a var
 
 ==== BTCPay Server
 
-While not initially designed as an installation "helper", the e-commerce and payment platform BTCPay Server has an incredibly easy installation system that uses docker containers and docker-compose to install a Bitcoin node, Lightning node and payment gateway, among many other services. It can be installed on a variety of hardware platforms, from a simple Raspberry Pi 4 (4GB recommended) to a mini-PC, old laptop, desktop or server.
+While not initially designed as an installation "helper", the e-commerce and payment platform _BTCPay Server_ has an incredibly easy installation system that uses docker containers and +docker-compose+ to install a Bitcoin node, Lightning node, and payment gateway, among many other services. It can be installed on a variety of hardware platforms, from a simple Raspberry Pi 4 (4GB recommended) to a mini-PC, old laptop, desktop or server.
 
-BTCPay server not only installs a full node for you, but that is a side-effect of what is a fully-featured self-hosted self-custody e-commerce platform that can be integrated with many e-commerce platforms such as Wordpress Woocommerce and others. Originally developed as a feature-for-feature replacement of the Bitpay commercial service and API, it has evolved past that to be a complete platform for BTC and Lighting services related to e-commerce.
+BTCPay Server is a fully-featured self-hosted self-custody e-commerce platform that can be integrated with many e-commerce platforms such as Wordpress Woocommerce and others. The installation of the full node is only a step of the e-commerce platform installation.
+While originally developed as a feature-for-feature replacement of the _Bitpay_ commercial payment service and API, it has evolved past that to be a complete platform for BTC and Lighting services related to e-commerce. For many sellers or shops it is a one-shop turn-key solution to e-commerce.
 
 More information can be found at:
 
 https://btcpayserver.org/
 
-In addition to a Bitcoin and Lightning node, BTCPay server can also install a variety of services including:
+In addition to a Bitcoin and Lightning node, BTCPay Server can also install a variety of services, including:
 
 - c-Lightning or LND Lightning node
 - Litecoin support
-- Monero suport
+- Monero support
 - Spark server (c-lightning web wallet)
 - Charge server (c-lightning e-commerce API)
 - Ride The Lightning (Lightning node management web GUI)
 - Many BTC forks
 - BTCTransmuter (event-action automation service supporting currency exchange)
 
-The number of additional services and features is expanding rapidly, so the list above is only a small subset of what is available in the BTCPay Server platform.
+The number of additional services and features is growing rapidly, so the list above is only a small subset of what is available on the BTCPay Server platform.
 
 ==== Bitcoin node or lightweight Lightning
 


### PR DESCRIPTION
- simplifications
- commas
-  "set up" is a verb, not a noun --> "setup"
- COLDCARDwallet --> They themselves on their website use predominantly "Coldcard Wallet". Their logo image does use uppercase, but they do not use uppercase in their text/manuals.
- a number is not expanding, a number is growing
- etc