### PR TITLE
Getting Started - Update wallet/node examples with Electrum

### DIFF
--- a/02_getting_started.asciidoc
+++ b/02_getting_started.asciidoc
@@ -107,6 +107,7 @@ In <<lnwallet-examples>> we see some examples of currently popular Lightning nod
 | c-lightning    | Server  | Full Node   | Bitcoin Core          | Self-Custody
 | Eclair Server  | Server  | Full Node   | Bitcoin Core/Electrum | Self-Custody
 | Zap Desktop    | Desktop | Full Node   | Neutrino              | Self-Custody
+| Electrum       | Desktop | Full Node   | Bitcoin Core/Electrum | Self-Custody
 | Eclair Mobile  | Mobile  | Lightweight | Electrum              | Self-Custody
 | Breez Wallet   | Mobile  | Full Node   | Neutrino              | Self-Custody
 | Phoenix Wallet | Mobile  | Lightweight | Electrum              | Self-Custody

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -175,6 +175,7 @@ Many contributors offered comments, corrections, and additions to the book as it
 Following is an alphabetically sorted list of all the GitHub contributors, including their GitHub IDs in parentheses:
 
 * 8go (@8go)
+* Alexander Gnip (@quantumcthulhu)
 * Alpha Q. Smith (@alpha_github_id)
 * Brian L. McMichael (@brianmcmichael)
 * Darius E. Parvin (@DariusParvin)


### PR DESCRIPTION
Electrum Release 4.0.1 - (July 3, 2020) supports Lightning Network. 
I think it has to be added to the "Examples of Popular Lightning Wallets".

https://github.com/spesmilo/electrum/blob/master/RELEASE-NOTES