### PR TITLE
Glossary - Payment Channels

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -341,23 +341,18 @@ payment::
     The invoice includes a payment hash which is the hash of a secret preimage.
     This payment hash is used by the Hashed Time Lock Contracts during the routing process.
 
-payment channels::
-    A micropayment channel or payment channel is a class of techniques designed to allow users to make multiple Bitcoin transactions without committing all of the transactions to the Bitcoin blockchain. In a typical payment channel, only two transactions are added to the blockchain, but an unlimited or nearly unlimited number of payments can be made between the participants.
-
 payment channel::
-    Payment channels are the core building blocks of the Lightning Network.
-    They can be used to send a predefined amount of bitcoin back and forth between two parties.
-    Sending bitcoin over a payment channel happens off chain, so only the funding transaction and either the commitment or closing transaction is stored in the blockchain.
-    There are currently three methods known to construct a fully duplex bidirectional payment channel.
-    Christian Decker proposed a method in his PhD thesis based on invalidation trees.
-    In the Lightning Network whitepaper, Joseph Poon and Tadge Dryja describe the Revocable Sequence Maturity Contract based method that is currently being implemented on the Lightning Network.
-    Recently Christian Decker et al. came up with the Eltoo mechanism which would require a Bitcoin softfork.
+    A payment channel is a financial relationship between two nodes on the Lightning Network, created using a multi-signature Bitcoin transaction.
+    The channel partners can use the channel to send Bitcoin back and forth between each other without committing all of the transactions to the Bitcoin blockchain. 
+    In a typical payment channel only two transactions, the funding transaction and the commitment transaction, are added to the blockchain.
+    The other transactions are not included in the blockchain and are said to occur "off-chain".
+    There are various methods of constructing a payment channel discussed further in the chapter on channel construction.
 
 peer::
     Two parties which form a payment channel are called peers.
     In particular, they are connected via an encrypted, authenticated communication over a TCP Socket.
 
-Penalty Transaction::
+penalty transaction::
     Look at the Breach Remedy Transaction.
 
 preimage::


### PR DESCRIPTION
Fixes #463 

The glossary contains two separate definitions for payment channels, both of which are probably too complex for a glossary