### PR TITLE
node_operations: fees: BUG, wrong math

### DIFF
--- a/node_operations.asciidoc
+++ b/node_operations.asciidoc
@@ -852,31 +852,31 @@ Running a Lightning node allows you to earn fees by routing payments across your
 
 Nodes compete for routing fees by setting their desired fee rate on each channel. Routing fees are set by two parameters on each channel: a fixed _base fee_ that is charged for any payment and an additional variable _fee rate_ that is proportional to the payment amount.
 
-When sending a Lightning payment, a node will select a path so as to minimize fees, minimize hops or both. As a result, a routing fee market emerges from these interactions. There are many nodes that charge very low or no fees for routing, creating downward pressure on the routing fee "market".
+When sending a Lightning payment, a node will select a path so as to minimize fees, minimize hops, or both. As a result, a routing fee market emerges from these interactions. There are currently many nodes that charge very low or no fees for routing, creating downward pressure on the routing fee "market".
 
-If you make no choices, your Lightning node will set a default base fee and fee rate for each new channel. The default values depend on the node implementation you use. Routing fees are set as millisatoshi (thousandths of a satoshi) for the base fee and millionths per satoshi for the proportional fee rate. For example, a base fee of 1000 (millisatoshi) and fee rate of 10 (millionths) would result in the following charges for a 100,000 satoshi payment:
+If you make no choices, your Lightning node will set a default base fee and fee rate for each new channel. The default values depend on the node implementation you use. The _base fee_ is set in the unit of _millisatoshi_ (thousandths of a satoshi). The proportional _fee rate_ is set in the unit of _millionths_ and is applied to the payment amount. For example, a _base fee_ of 1,000 (millisatoshi) and a _fee rate_ of 10 (millionths) would result in the following charges for a 1,000,000 satoshi payment:
 
 [latexmath]
 ====
-P = 100,000
+P = 1,000,000 satoshi
 
-F_base = 1000 millisatoshi
+F_base = 1,000 millisatoshi = 1 satoshi
 
-F_rate = 10/1,000,000 * payment size
+F_rate = 10/1,000,000
 
-F_total = F_base + F_rate * P
+F_total = F_base + ( F_rate * P )
 
- \Rightarrow  F_total = 1 satoshi + 100 satoshi
+ \Rightarrow  F_total = 1 satoshi + 10 satoshi
 
- \Rightarrow  F_total = 101 satoshi
+ \Rightarrow  F_total = 11 satoshi
 
 ====
 
-Broadly speaking, you can take one of two approaches to routing fees. You can route lots of payments with low fees, making up for low fees by lots of volume. Or you can choose to charge higher fees, expecting you will route fewer payments. If you choose to set higher fees your node will be selected only when other cheaper routes don't exist. Therefore, you will route less often but earn more per successful routing.
+Broadly speaking, you can take one of two approaches to routing fees. You can route lots of payments with low fees, making up for low fees by high volume. Alternatively, you can choose to charge higher fees. If you choose to set higher fees, your node will be selected only when other cheaper routes don't exist. Therefore, you will route less frequently but earn more per successful routing.
 
-For most nodes, it is usually best to leave the default routing fee values, so that your node is competing on a mostly level playing field with other nodes who use the default values.
+For most nodes, it is usually best to use the default routing fee values. This way, your node is competing on a mostly level playing field with other nodes who use the default values.
 
-You can also use the routing fee settings to re-balance channels. If most of your channels have the default fees but you want to rebalance a channel, just decrease the fees on that channel to zero or very low rates. Then sit back and wait for someone to route a payment over your "cheap" route and re-balance your channels for you as a side-effect.
+You can also use the routing fee settings to re-balance channels. If most of your channels have the default fees but you want to rebalance a particular channel, just decrease the fees on that specific channel to zero or to very low rates. Then sit back and wait for someone to route a payment over your "cheap" route and re-balance your channels for you as a side-effect.
 
 === Node management
 


### PR DESCRIPTION
- "millionths per satoshi" ==> it is a rate, so it is just "millionths". Just like interest rate is 2% and not "2% per $" or "2%/$"
- rephrased and highlighted to make it more clear, more easy to follow
- changed 100,000 amount to 1,000,000 solely that at the end F_base and F_rate*P are different (different numbers make a better example)
- there was a BUG: in given example F_rate is 1 (not 100), correct total was 2 and not 101 as presented
- "F_rate = 10/1,000,000 * payment size" ==> wrong: ==> F_rate = 10/1,000,000 is correct
- put ( ) around F_rate * P to make it extra clear
- \Rightarrow is NOT showing correctly in "Preview" window, not sure why, \Rightarrow is correct Latex but not shown correctly here. I did not touch it. Maybe this is handled by post-processing.