### PR TITLE
Chapter 1,2,3 - punctuation, typos, simplifications

### DIFF
--- a/01_introduction.asciidoc
+++ b/01_introduction.asciidoc
@@ -19,11 +19,11 @@ While the bulk of this book is written for programmers, the first two chapters a
 
 As Bitcoin and the demand for transactions grows, the number of transactions in each block will increase until it eventually hits the block size limit.
 When blocks are full, excess transactions are left to wait in a queue.
-Many users will increase the fees they're willing to pay in order to buy space for their transaction in the next block.
+Many users will increase the fees they're willing to pay in order to buy space for their transactions in the next block.
 At the same time, an increasing number of users are left behind.
 Their transactions, e.g. microtransactions such as common small spendings, are not economically qualified to be on the network.
 We could increase the block size to create space for these smaller transactions.
-However, increasing block size simply shifts the problem to node operators, and requires them to expend resources to faciliate these additional transactions.
+However, increasing block size simply shifts the problem to node operators, and requires them to expend resources to facilitate these additional transactions.
 
 Because blockchains are gossip protocols, each node is required to know and validate every single transaction that occurs on the network. Furthermore, once validated, each transaction and block must be propagated to the node's "neighbors", multiplying the bandwidth requirements. As such, the greater the block size, the greater the bandwidth, processing, and storage requirements for each individual node, effectively limiting the amount of scaling that can be done this way. Furthermore, scaling in this fashion has an undesirable side effect of centralizing the network by reducing the number of nodes and node operators. Since node operators are not compensated for running nodes, if nodes are very expensive to run, only a few well funded node operators will continue to run nodes.
 
@@ -33,9 +33,9 @@ The side effects of increasing the block size or decreasing the block time with 
 Let us assume the usage of Bitcoin grows so that the network has to process 40,000 transactions per second.
 Assuming 250 Bytes on average per transaction this would result in a data stream of 10 Megabyte per second or 80 Mbit/s just to be able to receive all the transactions.
 This does not include the traffic overhead of forwarding the transaction information to other peers.
-While 10 MB/s does not seem extreme in the context of high speed fibre and 5G mobile speeds, it would effectively exclude anyone who cannot meet this requirement from running a node, especially in countries where high-performance internet is not affordable or widely available.
-Users also have many other demands on their bandwidth and cannot be expected to expend this much only to receieve transactions. 
-Furthermore storing this information locally would result in 864,000 Megabyte per day. This is roughly 1 Terabyte of data or the size of a hard drive.
+While 10 MB/s does not seem extreme in the context of high-speed fibre and 5G mobile speeds, it would effectively exclude anyone who cannot meet this requirement from running a node, especially in countries where high-performance internet is not affordable or widely available.
+Users also have many other demands on their bandwidth and cannot be expected to expend this much only to receive transactions. 
+Furthermore storing this information locally would result in 864,000 Megabytes per day. This is roughly 1 Terabyte of data or the size of a hard drive.
 While verifying 40,000 ECDSA signatures per second seems barely feasible (c.f.: https://bitcoin.stackexchange.com/questions/95339/how-many-bitcoin-transactions-can-be-verified-per-second) nodes could hardly catch up initial sync of the blockchain. 
 ====
 
@@ -73,18 +73,18 @@ Payment Channel:: A _financial relationship_ between two nodes on the Lightning 
 
 On-Chain vs. Off-Chain:: A payment is "on-chain" if it is recorded as a transaction on the Bitcoin (or other underlying) blockchain. Payments sent via payment channels between Lightning nodes, and which are not visible in the underlying blockchain, are called "off-chain" payments.
 
-More detailed definitions of these and many other terms can be found in the <<glossary>>. Throughout this book we will explain what these concepts mean and how these technologies actually work.
+More detailed definitions of these and many other terms can be found in the <<glossary>>. Throughout this book, we will explain what these concepts mean and how these technologies actually work.
 
 [TIP]
 ====
-Throughout this book you will see "Bitcoin" with the first letter capitalized, which refers to the _Bitcoin System_ and is a proper noun. You will also see "bitcoin", with a lower-case _b_, which refers to the currency unit.
+Throughout this book, you will see "Bitcoin" with the first letter capitalized, which refers to the _Bitcoin System_ and is a proper noun. You will also see "bitcoin", with a lower-case _b_, which refers to the currency unit.
 ====
 
 === What is the Lightning Network?
 
 The Lightning Network is a network that operates as a "second layer" protocol on top of Bitcoin and other blockchains. The Lightning Network enables fast, secure, private, trustless, and permissionless payments. Here are some of the features of the Lightning Network:
 
- * Users of the Lightning Network can route payments to each other for low cost and in real time.
+ * Users of the Lightning Network can route payments to each other for low cost and in real-time.
  * Users who exchange value over the Lightning Network do not need to wait for block confirmations for payments.
  * Once a payment on the Lightning Network has completed, usually within a few seconds, it is final and cannot be reversed. Like a Bitcoin transaction, a payment on the Lightning Network can only be refunded by the recipient.
  * While "on-chain" Bitcoin transactions are broadcast and verified by all nodes in the network, payments routed on the Lightning Network are transmitted between pairs of nodes and are not visible to everyone, resulting in much greater privacy. 
@@ -126,4 +126,4 @@ Wei is an entrepreneur who sells information services related to the Lightning N
 
 === Chapter Summary
 
-In this chapter we looked at the history of the Lightning Network and the motivations behind second layer scaling solutions for Bitcoin and other blockchain based networks. We learned basic terminology including node, payment channel, on-chain transactions, and off-chain payments. Finally, we met Alice, Bob, Saanvi, John, Gloria, Farel, and Wei who we'll be following throughout the rest of the book. In the next chapter we'll meet Alice and walk through her thought process as she selects a Lightning wallet and prepares to make her first Lightning payment to buy a cup of coffee from Bob's Cafe.
+In this chapter, we looked at the history of the Lightning Network and the motivations behind second layer scaling solutions for Bitcoin and other blockchain based networks. We learned basic terminology including node, payment channel, on-chain transactions, and off-chain payments. Finally, we met Alice, Bob, Saanvi, John, Gloria, Farel, and Wei who we'll be following throughout the rest of the book. In the next chapter, we'll meet Alice and walk through her thought process as she selects a Lightning wallet and prepares to make her first Lightning payment to buy a cup of coffee from Bob's Cafe.

--- a/02_getting_started.asciidoc
+++ b/02_getting_started.asciidoc
@@ -26,7 +26,7 @@ The below is an inexhaustive list (in alphanumerical order):
 Note that when using Lightning explorers, just like with existing block explorers, privacy can be a concern.
 If users are careless, the website may track their IP addresses and collect their behavior records (for example, the nodes users are interested in).
 
-Also it should be noted that as there is no global consensus of the current Lightning graph or the current state of any existing channel policy, users should never rely on Lightning explorers to retrieve the most updated information.
+Also, it should be noted that as there is no global consensus of the current Lightning graph or the current state of any existing channel policy, users should never rely on Lightning explorers to retrieve the most updated information.
 Furthermore as users open, close, and update channels, the graph will change and individual Lightning explorers may not be up to date.
 Users should instead be running their own node to build a channel graph and stay informed of the latest state of the network.
 Where they use Lightning explorers, it should be sparingly or to gather statistics.
@@ -53,7 +53,7 @@ Blockchains, especially open blockchains like Bitcoin, attempt to minimize or el
 
 Every other component of a Lightning wallet brings similar considerations of trust. If all the components are under the control of the user, then the amount of trust in third parties is minimized, bringing maximum power to the user. Of course, this brings a direct trade-off, as with that power comes the corresponding responsibility to manage complex software.
 
-Every user must consider their own technical skills before deciding what type of Lightning wallet to use. Those with strong technical skills should use a Lightning wallet that puts all of the components under the direct control of the user. Those with fewer technical skills but a desire to control their funds, should choose a _non-custodial_ Lightning wallet.
+Every user must consider their own technical skills before deciding what type of Lightning wallet to use. Those with strong technical skills should use a Lightning wallet that puts all of the components under the direct control of the user. Those with fewer technical skills but a desire to control their funds should choose a _non-custodial_ Lightning wallet.
 Often the trust in those cases relates to privacy.
 If users decide to outsource some functionality to a third party they usually give up some privacy as the third party will learn some information about them.
 
@@ -87,7 +87,7 @@ Lightning wallets can be installed on a variety of devices, including laptops, s
 
 The category "Third-party Lightning Nodes" can again be subdivided into:
 
-- Lightweight: means that the Lightning Node is operated by a third party and that the wallet obtains the required information through an API that connects wallet and third-party Lightning node.
+- Lightweight: means that the Lightning Node is operated by a third party and that the wallet obtains the required information through an API that connects the wallet and third-party Lightning node.
 - None: means that not only is the Lightning Node operated by a third party but most of the wallet is operated by a third party in the cloud such that the wallet does not even need to make calls on a Lightning node API.
 
 These subcategories are used in Table <<lnwallet-examples>>.
@@ -144,7 +144,7 @@ Alice uses an Android device and will use the Google Play Store to download and 
 .Eclair Mobile in the Google Play Store
 image:images/eclair-playstore.png["Eclair wallet in the Google Play Store"]
 
-Alice notices a few different elements on this page, that help her ascertain that this is, most likely, the correct "Eclair Mobile" wallet she is looking for. Firstly, the organization "ACINQ" footnote:[ACINQ: Developers of the Eclair Mobile Lightning wallet (https://acinq.co/).] is listed as the developer of this mobile wallet, which Alice knows from her research is the correct developer. Secondly, the wallet has been installed "10,000+" times and has more than 320 positive reviews. It is unlikely this is a rogue app that has snuck into the Play Store. As third step, she goes to the ACINQ website (https://acinq.co/). She verifies that the webpage is secure (https, not http) which is shown as a green lock by some browsers. On the website she goes to the Download section or looks for the link to the Google App store. She finds the link and clicks it. She compares that this link brings her to the very same app in the Google App Store. Satisfied by these findings, Alice installs the Eclair app on her mobile device.
+Alice notices a few different elements on this page, that help her ascertain that this is, most likely, the correct "Eclair Mobile" wallet she is looking for. Firstly, the organization "ACINQ" footnote:[ACINQ: Developers of the Eclair Mobile Lightning wallet (https://acinq.co/).] is listed as the developer of this mobile wallet, which Alice knows from her research is the correct developer. Secondly, the wallet has been installed "10,000+" times and has more than 320 positive reviews. It is unlikely this is a rogue app that has snuck into the Play Store. As a third step, she goes to the ACINQ website (https://acinq.co/). She verifies that the webpage is secure (https, not http) which is shown as a green lock by some browsers. On the website she goes to the Download section or looks for the link to the Google App store. She finds the link and clicks it. She compares that this link brings her to the very same app in the Google App Store. Satisfied by these findings, Alice installs the Eclair app on her mobile device.
 
 [WARNING]
 ====
@@ -157,7 +157,7 @@ When Alice opens the Eclair Mobile app for the first time, she is presented with
 
 ==== Responsibility with Key Custody
 
-As we mentioned in the beginning of this section, Eclair is a _non-custodial_ wallet, meaning that Alice has sole custody of the keys used to control her bitcoin. This also means that Alice is responsible for protecting and backing up those keys. If Alice loses the keys, no one can help her recover the bitcoin, and they will be lost forever.
+As we mentioned at the beginning of this section, Eclair is a _non-custodial_ wallet, meaning that Alice has sole custody of the keys used to control her bitcoin. This also means that Alice is responsible for protecting and backing up those keys. If Alice loses the keys, no one can help her recover the bitcoin, and they will be lost forever.
 
 [WARNING]
 ====
@@ -256,9 +256,9 @@ Similarly, if she billed a client for a service offered over the Internet, Alice
 Alice could even print the QR code and affix it to a sign and display it publicly to receive tips. For example, she could have a QR code affixed to her guitar and receive tips while performing on the street!
 footnote:[It is generally not advisable to reuse the same Bitcoin address for multiple payments as all Bitcoin transactions are public.
 A nosy person passing by could scan Alice's QR code and see how many tips Alice has already received to this address on the Bitcoin blockchain.
-Fortunately the Lightning Network offers more private solutions to this, discussed later in the book!]
+Fortunately, the Lightning Network offers more private solutions to this, discussed later in the book!]
 
-Finally, if Alice bought bitcoin from a crypto-currency exchange, she could (and should) "withdraw" the bitcoin by pasting her Bitcoin Address into the exchange website. The exchange will then send the bitcoin to her address directly.
+Finally, if Alice bought bitcoin from a cryptocurrency exchange, she could (and should) "withdraw" the bitcoin by pasting her Bitcoin Address into the exchange website. The exchange will then send the bitcoin to her address directly.
 
 === From Bitcoin to Lightning Network
 
@@ -307,7 +307,7 @@ image:images/node-URI-QR.png[width=120]
 
 While Alice could select a specific Lightning node, or use the "Random node" option to have the Eclair wallet select a node at random, she will select the "ACINQ Node" option to connect to one of ACINQ's well-connected Lightning nodes.
 
-Choosing the ACINQ node will slightly reduce Alice's privacy, as it will give ACINQ the ability to see all of Alice's transactions. It will also create a Single Point of Failure, since Alice will only have one channel, and if the ACINQ node is not available, Alice will not be able to make payments. To keep things simple at first, we will accept these trade-offs. In subsequent chapters we will gradually learn how to gain more independence and make fewer trade-offs!
+Choosing the ACINQ node will slightly reduce Alice's privacy, as it will give ACINQ the ability to see all of Alice's transactions. It will also create a Single Point of Failure, since Alice will only have one channel, and if the ACINQ node is not available, Alice will not be able to make payments. To keep things simple at first, we will accept these trade-offs. In subsequent chapters, we will gradually learn how to gain more independence and make fewer trade-offs!
 
 Alice selects "ACINQ Node" and is ready to open her first channel on the Lightning network.
 
@@ -337,7 +337,7 @@ image:images/eclair-channel-open.png["Channel is Open"]
 
 [TIP]
 ====
-Did you notice that the channel amount seems to have changed? It hasn't: the channel contains 0.018 BTC, but in the time between screenshots the BTC exchange rate changed, so the USD value is different. You can choose to show balances in BTC or USD, but keep in mind that USD values are calculated in real time and will change!
+Did you notice that the channel amount seems to have changed? It hasn't: the channel contains 0.018 BTC, but in the time between screenshots the BTC exchange rate changed, so the USD value is different. You can choose to show balances in BTC or USD, but keep in mind that USD values are calculated in real-time and will change!
 ====
 
 === Buying a Cup of Coffee
@@ -348,7 +348,7 @@ Alice grabs her mobile device and runs to Bob's Cafe in her neighborhood. She is
 
 ==== Bob's Cafe
 
-Bob has a simple Point-of-Sale (PoS) application for the use of any customer who wants to pay with bitcoin over the Lightning Network. As we will see in the next chapter, Bob uses the popular open source platform _BTCPay Server_ which contains all the necessary components for an e-commerce or retail solution, such as:
+Bob has a simple Point-of-Sale (PoS) application for the use of any customer who wants to pay with bitcoin over the Lightning Network. As we will see in the next chapter, Bob uses the popular open-source platform _BTCPay Server_ which contains all the necessary components for an e-commerce or retail solution, such as:
 
 * A Bitcoin Node using the Bitcoin Core software
 * A Lightning Node using the c-lightning software
@@ -382,7 +382,7 @@ Alice selects the option to "scan a payment request" and scans the QR code displ
 .Alice's Send Confirmation
 image:images/alice-send-detail.png[width=300]
 
-Alice presses "PAY," and a second later, Bob's tablet shows a successful payment. Alice has completed her first Lightning Network payment! It was fast, inexpensive, and easy. Now she can enjoy her latte which was purchased using the most advanced payment technology in the world. And from now on, whenever Alice feels like drinking a coffee at Bob's Cafe she selects an item on Bob's tablet screen, scans the QR code with her cell phone, clicks pay and is served a coffee, all within seconds and all without "on-chain" transaction.
+Alice presses "PAY," and a second later, Bob's tablet shows a successful payment. Alice has completed her first Lightning Network payment! It was fast, inexpensive, and easy. Now she can enjoy her latte which was purchased using the most advanced payment technology in the world. And from now on, whenever Alice feels like drinking a coffee at Bob's Cafe she selects an item on Bob's tablet screen, scans the QR code with her cell phone, clicks pay, and is served a coffee, all within seconds and all without "on-chain" transaction.
 
 
 === Conclusion

--- a/03_how_ln_works.asciidoc
+++ b/03_how_ln_works.asciidoc
@@ -32,7 +32,7 @@ The ability to hold a partially-signed transaction, offline and unpublished, wit
 
 === Routing payments across channels
 
-Once several participants have channels from one party to another, a payment can also be "forwarded" from payment channel to payment channel, by setting up a _path_ across the network connecting several payment channels together.
+Once several participants have channels from one party to another, payment can also be "forwarded" from payment channel to payment channel, by setting up a _path_ across the network connecting several payment channels together.
 
 For example, Alice can send money to Charlie if Alice has a channel with Bob and Bob has a channel with Charlie.
 
@@ -47,7 +47,7 @@ However, the Lightning Network is so much more than the cryptographic protocols 
 It is a comprehensive communication protocol that allows peers to exchange Lightning messages to achieve the transfer of bitcoin.
 The communication protocol defines how Lightning messages are encrypted and exchanged.
 
-The Lightning Network also uses a "gossip" protocol to distribute public information about the  channels (network topology) to all the participants.
+The Lightning Network also uses a "gossip" protocol to distribute public information about the channels (network topology) to all the participants.
 
 Alice, for example, needs the network topology information to be aware of the channel between Bob and Charlie, so that she can construct a route to Charlie.
 
@@ -72,7 +72,7 @@ Payment channels have a few very interesting and useful properties:
 
 * The cryptographic protocol is constructed such that there is little to no trust needed between you and your channel partner. If your partner becomes unresponsive or tries to cheat you, you can ask the Bitcoin system to act as a "court" resolving the smart contract you and your partner have previously agreed upon.
 
-* Payments made in a payment channel are only known to you and your partner. In that sense you gain privacy compared to Bitcoin, where every transaction is public.  Only the final balance, which is the aggregate of all payments in that channel, will become visible on the Bitcoin blockchain.
+* Payments made in a payment channel are only known to you and your partner. In that sense, you gain privacy compared to Bitcoin, where every transaction is public.  Only the final balance, which is the aggregate of all payments in that channel, will become visible on the Bitcoin blockchain.
 
 
 Bitcoin was about 5 years old when talented developers first figured out how payment channels could be constructed and by now there are at least 3 different methods known.
@@ -107,7 +107,7 @@ K <PubKey1> <PubKey2> ... PubKeyN N CHECKMULTISIG
 
 where N is the total number of listed public keys (Public Key 1 through Public Key N) and K is the threshold of required signatures to spend the output.
 
-The Lightning Network uses a 2-of-2 multisignature scheme to build a payment channel. For example, a payment channel between Alice and Bob would be build on a 2-of-2 multisignature like this:
+The Lightning Network uses a 2-of-2 multisignature scheme to build a payment channel. For example, a payment channel between Alice and Bob would be built on a 2-of-2 multisignature like this:
 
 ----
 2 <PubKey Alice> <PubKey Bob> 2 CHECKMULTISIG
@@ -135,7 +135,7 @@ The amount deposited in the multisignature address is called the _channel capaci
 
 [NOTE]
 ====
-The funds sent to the multisignature address in the funding transaction are sometimes referred to as "locked in a Lightning channel". However in practice, funds in a Lightning channel are not "locked" but rather "unleashed". Lightning channel funds are more liquid than funds on the Bitcoin blockchain as they can be spent faster, cheaper and more privately. Opening a Lightning channel unleashes your Bitcoin!
+The funds sent to the multisignature address in the funding transaction are sometimes referred to as "locked in a Lightning channel". However, in practice, funds in a Lightning channel are not "locked" but rather "unleashed". Lightning channel funds are more liquid than funds on the Bitcoin blockchain as they can be spent faster, cheaper and more privately. Opening a Lightning channel unleashes your Bitcoin!
 ====
 
 ===== Example of a poor channel opening procedure
@@ -146,9 +146,9 @@ Alice and Bob want to create a payment channel. They each create a private/publi
 
 Next, Alice constructs a Bitcoin transaction sending a few mBTC to the multisignature address created from Alice's and Bob's public keys. If Alice doesn't take any additional steps and simply broadcasts this transaction, she has to trust that Bob will provide his signature to spend from the multisignature address. Bob on the other hand has the chance to blackmail Alice by withholding his signature and denying Alice access to her funds.
 
-In order to prevent this, Alice will need to create an additional transaction which spends from the multisignature address, refunding her mBTC. Alice then has Bob sign the refund transaction _before_ broadcasting her funding transaction to the Bitcoin network. This way, Alice can get a refund even if Bob disappears or fails to cooperate.
+In order to prevent this, Alice will need to create an additional transaction that spends from the multisignature address, refunding her mBTC. Alice then has Bob sign the refund transaction _before_ broadcasting her funding transaction to the Bitcoin network. This way, Alice can get a refund even if Bob disappears or fails to cooperate.
 
-The "refund" transaction that protects Alice is the first of a class of transactions called _commitment transactions_, which we will examine  in more detail next.
+The "refund" transaction that protects Alice is the first of a class of transactions called _commitment transactions_, which we will examine in more detail next.
 
 ==== Commitment Transaction
 
@@ -159,7 +159,7 @@ By holding a signed commitment transaction, each channel partner can get their f
 The commitment transaction that Alice prepared in the previous example, was a "refund" of her initial payment to the multisignature address. More generally however, a commitment transaction splits the funds of the payment channel, paying the two channel partners according to the distribution (balance) they each hold. At first, Alice holds all the balance, so it is a simple refund. But as funds flow from Alice to Bob, they will exchange signatures for new commitment transactions that represent the new balance distribution, with some part of the funds paid to Alice and some paid to Bob.
 
 Let us assume Alice opens a channel with a capacity of 100k satoshi with Bob.
-Initially Alice owns 100k satoshi, the entirety of the funds in the channel. Here's how the payment channel protocol would work:
+Initially, Alice owns 100k satoshi, the entirety of the funds in the channel. Here's how the payment channel protocol would work:
 
 . Alice creates a new private / public key pair and informs Bob that she wishes to open a channel via the `open_channel` message (a message in the Lightning Network protocol).
 . Bob also creates a new private / public key pair and agrees to accept a channel from Alice, sending his public key to Alice via the `accept_channel` message.
@@ -187,7 +187,7 @@ Now that we understand commitment transactions, let's look at some of the more s
 How many commitment transactions does Alice hold after she pays 30k satoshi to Bob? She holds two: the original one paying her 100k satoshi and the more recent one, paying her 70k satoshi and Bob 30k satoshi.
 
 In the channel protocol we have seen so far, nothing stops Alice from publishing a previous commitment transaction. A cheating Alice could publish the commitment transaction which grants her 100k satoshi.
-Since that commitment transaction  was signed by Bob he can't prevent Alice from transmitting it.
+Since that commitment transaction was signed by Bob he can't prevent Alice from transmitting it.
 
 Some mechanism is needed to prevent Alice from publishing an old commitment transaction. Let us now find out how this can be achieved and how it enables the Lightning Network to operate without requiring any trust between Alice and Bob.
 
@@ -217,13 +217,13 @@ Now that we understand _why_ a penalty mechanism is needed and how it will preve
 
 Usually, the commitment transaction has at least two outputs, paying each channel partner. We change this to add a _timelock delay_ and a _revocation secret_, to one of the payments. The timelock prevents the owner of the output from spending it immediately once the commitment transaction is included in a block. The revocation secret allows either party to immediately spend that payment, bypassing the timelock.
 
-So, in our example, Bob holds a commitment transaction which pays Alice _immediately_, but his own payment is delayed and revocable. Alice also holds a commitment transaction, but hers is the opposite: it pays Bob immediately but her own payment is delayed and revocable.
+So, in our example, Bob holds a commitment transaction that pays Alice _immediately_, but his own payment is delayed and revocable. Alice also holds a commitment transaction, but hers is the opposite: it pays Bob immediately but her own payment is delayed and revocable.
 
 The two channel partners hold half of the revocation secret, so that neither one knows the whole secret. If they share their half, then the other channel partner has the full secret and can use it to exercise the revocation condition. When signing a new commitment transaction, they revoke the previous commitment by exchanging the signature for the revocation secret.
 
 In simple terms, Alice signs Bob's new commitment transaction only if Bob offers his half of the revocation secret for the previous commitment. Bob only signs Alice's new commitment transaction if she gives him her half of the revocation secret from the previous commitment.
 
-With each new commitment, they exchange the necessary "punishment" secret that allows them to effectively _revoke_ the prior commitment transaction by making it unprofitable to transmit. Essentially, they destroy the ability to use the old commitments as they sign the new ones. footnote:[It is still technically possible to use old commitments, but the penalty mechanism makes it economically irrational to do so.]
+With each new commitment, they exchange the necessary "punishment" secret that allows them to effectively _revoke_ the prior commitment transaction by making it unprofitable to transmit. Essentially, they destroy the ability to use old commitments as they sign the new ones. footnote:[It is still technically possible to use old commitments, but the penalty mechanism makes it economically irrational to do so.]
 
 The timelock is set to a number of blocks, up to 2016 (approximately two weeks). If either channel partner publishes a commitment transaction without cooperating with the other partner, they will have to wait for that number of blocks (e.g. 2 weeks) to claim their balance. The other channel partner can claim their own balance at any time. Furthermore, if the commitment they published was previously revoked, the channel partner can *also* immediately claim the cheating party's balance, bypassing the timelock and punishing the cheater.
 
@@ -264,7 +264,7 @@ When new nodes join the Lightning Network they collect the channel announcements
 ==== Closing the channel
 
 The best way to close a channel is... to not close it! 
-Opening and closing channels requires an on-chain transaction, which will incur transaction fees. 
+Opening and closing channels require an on-chain transaction, which will incur transaction fees. 
 So it's best to keep channels open as long as possible. 
 You can keep using your channel to make and forward payments, as long as you have sufficient capacity on your end of the channel. 
 But even if you send all the balance to the other end of the channel, you can then use the channel to receive payments from your channel partner. 
@@ -351,10 +351,10 @@ A Protocol Breach is when your channel partner tries to cheat you, whether delib
 
 Your node must be online and watching new blocks and transactions on the Bitcoin blockchain to detect this.
 Because your channel partner's payment will be encumbered by a timelock, your node has some time to act.
-You have until the time lock expires to detect a protocl breach and publish a _punishment transaction_.
-If you successfully detect the protocol breach and enforce the penalty, you will receive all of the funds in channel, including your channel partner's funds.
+You have until the time lock expires to detect a protocol breach and publish a _punishment transaction_.
+If you successfully detect the protocol breach and enforce the penalty, you will receive all of the funds in the channel, including your channel partner's funds.
 
-In this scenario the channel closure will be rather fast.
+In this scenario, the channel closure will be rather fast.
 You will have to pay on-chain fees to publish the punishment transaction, but your node can set these fees according to the fee estimation and not overpay.
 You will generally want to pay higher fees to guarantee confirmation as soon as possible.
 However, as you will eventually receive all of the cheater's funds, it is essentially the cheater who will be paying for this transaction.
@@ -398,7 +398,7 @@ There is a way to send an "unsolicited" payment without an invoice, using a work
 
 An invoice is a simple payment instruction containing information such as a unique payment identifier, called a payment hash, a recipient, an amount, and an optional text description.
 
-The most important part of the invoice is the payment hash, that allows the payment to travel across multiple channel in an _atomic_ way. Atomic, in computer science, means any action or state change that is either completed successfully or not at all - there is no possibility of an intermediate state or partial action. In the Lightning Network that means that the payment either travels the whole path or fails completely. It cannot be partially completed such that an intermediate node on the path can receive the payment and keep it.
+The most important part of the invoice is the payment hash, that allows the payment to travel across multiple channels in an _atomic_ way. Atomic, in computer science, means any action or state change that is either completed successfully or not at all - there is no possibility of an intermediate state or partial action. In the Lightning Network that means that the payment either travels the whole path or fails completely. It cannot be partially completed such that an intermediate node on the path can receive the payment and keep it.
 There is no such thing as a "partial payment" or "partly successful payment".
 
 Invoices are not communicated over the Lightning Network. Instead, they are communicated "out of band", using any other communication mechanism. This is similar to how Bitcoin addresses are communicated to senders outside the Bitcoin network, as a QR code, over email, or a text message. For example, Bob can present a Lightning invoice to Alice as a QR code, or send it via email, or any other message channel.
@@ -425,9 +425,9 @@ There is no known way to find the inverse of SHA256 (compute a preimage from a h
 
 The payment process of the Lightning Network is only secure if +r+ is chosen completely randomly and is not predictable. This security relies on the fact that hash functions cannot be inverted or feasibly brute-forced and therefore no one can find +r+ from +H+.
 
-==== Additional Meta Data
+==== Additional Metadata
 
-Invoices can optionally include other useful meta data such as a short text description. If a user has several invoices to pay, the user can read the description and be reminded what the invoice is about.
+Invoices can optionally include other useful metadata such as a short text description. If a user has several invoices to pay, the user can read the description and be reminded of what the invoice is about.
 
 The invoice can also include some _routing hints_, which allow the sender to use unannounced channels to construct a route to the recipient. Routing hints can also be used to suggest public channels, for example channels known by the recipient to have enough inbound capacity to route the payment.
 
@@ -445,7 +445,7 @@ Lightning invoices contain an expiry date. Since the recipient must keep the pre
 
 We have seen how the recipient creates an invoice that contains a payment hash. This payment hash will be used to move the payment across a series of payment channels, from sender to recipient, even if they do not have a direct payment channel between them.
 
-In the next few sections we will dive into the ideas and methods that are being used to deliver a payment over the Lightning Network and use all the concepts we have presented so far.
+In the next few sections, we will dive into the ideas and methods that are being used to deliver a payment over the Lightning Network and use all the concepts we have presented so far.
 
 First, let's look at the Lightning network's communication protocol.
 
@@ -457,15 +457,15 @@ Channel announcements are communicated over a peer-to-peer _gossip protocol_. A 
 
 After opening a channel, a node may choose to send out an announcement of the channel via the `channel_announcement` message to its peers.
 Every peer validates the information from the `channel_announcement` message and verifies that the funding transaction is confirmed on the Bitcoin blockchain.
-After verification the node will forward the gossip message to its own peers, and they will forward to their peers and so on, spreading the announcement across the entire network.
+After verification the node will forward the gossip message to its own peers, and they will forward it to their peers and so on, spreading the announcement across the entire network.
 In order to avoid excessive communication the channel announcement is only forwarded by each node if it has not already forwarded that announcement previously.
 
 The gossip protocol is also used to announce information about known nodes, with the `node_announcement` message.
 For this message to be forwarded a node has to have at least one public channel announced on the gossip protocol, again to avoid excessive communication traffic.
 
-Payment channels have various meta data that are useful for other participants of the network.
-This meta data is mainly used for making routing decisions.
-Since nodes might occasionally change the meta data of their channels, this information is shared in a `channel_update` message.
+Payment channels have various metadata that are useful for other participants of the network.
+This metadata is mainly used for making routing decisions.
+Since nodes might occasionally change the metadata of their channels, this information is shared in a `channel_update` message.
 These messages will only be forwarded approximately four times a day (per channel) to prevent excessive communication.
 The gossip protocol also has a variety of queries and messages to initially synchronize a node with the view of the network or to update the node's view after being offline for a while.
 
@@ -478,7 +478,7 @@ While Lightning could have been designed to share balance information of channel
 
 . To protect the privacy of the users and not shout out every financial transaction and payment that is being conducted. Channel balance updates would reveal that a payment has moved across the channel. This information could be correlated to reveal all payment sources and destinations.
 
-. To scale the amount of payments that can be conducted with the Lightning Network. Remember that the Lightning Network was created in the first place because notifying every participant about every payment does not scale well. Thus, the Lightning Network cannot be designed in a way that balance updates of channels are  shared among participants.
+. To scale the amount of payments that can be conducted with the Lightning Network. Remember that the Lightning Network was created in the first place because notifying every participant about every payment does not scale well. Thus, the Lightning Network cannot be designed in a way that balance updates of channels are shared among participants.
 
 . The Lightning Network is a dynamic system. It changes constantly and frequently. Nodes are being added, other nodes are being turned off, balances change, etc. Even if everything is always communicated, the information will be valid only for a short amount of time. As a matter of fact, information is often outdated by the time it is received.
 
@@ -488,43 +488,43 @@ For now, it is only important to know that the gossip protocol exists and that i
 This topology information is crucial for delivering payments through the network of payment channels.
 
 
-==== Path finding and routing
+==== Pathfinding and routing
 
-Payments on the Lightning Network are forwarded along a _path_ made of channels linking one participant to another, from the payment source to the payment destination. The process of finding a path from source to destination is called _path finding_. The process of using that path to make the payment is called _routing_.
-
-[NOTE]
-====
-A frequent criticism of the Lightning network is that "routing" is not solved, or even is an "unsolvable" problem. In fact, routing is trivial. Path finding, on the other hand, is a difficult problem. The two terms are often confused and need to be clearly defined to identify which problem we are attempting to solve.
-====
-
-As we will see next, the Lightning Network currently uses a _source-based_ protocol for path finding and an _onion routed_ protocol for routing payments. Source-based means that the sender of the payment has to find a path through the network to the intended destination. Onion-routed means that the elements of the path are layered (like an onion), with each layer encrypted so that it can only be seen by one node at a time. We will discuss onion routing in the next section.
-
-=== Source-based Path Finding
-
-If we knew the exact channel balances of every channel we could easily compute a payment path using any of the standard path finding algorithms taught in any computer science program. This could even be solved in a way that optimizes the fees paid to nodes for forwarding the payment.
-
-However, the balance information of all channels is not and cannot be known to all participants of the network. We need more innovative path finding strategies.
-
-With only partial information about the network topology, path finding is a real challenge and active research is still being conducted into this part of the Lightning Network. The fact that the path finding problem is not "fully solved" in the Lightning Network is a major point of criticism towards the technology.
+Payments on the Lightning Network are forwarded along a _path_ made of channels linking one participant to another, from the payment source to the payment destination. The process of finding a path from source to destination is called _pathfinding_. The process of using that path to make the payment is called _routing_.
 
 [NOTE]
 ====
-One common criticism of path-finding in the Lightning network is that it is unsolvable because it is equivalent to the NP-complete _Traveling Salesperson Problem_, a fundamental problem in computational complexity theory. In fact, path finding in Lightning is not equivalent to TSP and falls into a different class of problems. We successfully solve these types of problems (path finding in graphs with incomplete information) every time we ask Google to give us driving directions with traffic avoidance. We also successfully solve this problem every time we route a payment on the Lightning network.
+A frequent criticism of the Lightning network is that "routing" is not solved, or even is an "unsolvable" problem. In fact, routing is trivial. Pathfinding, on the other hand, is a difficult problem. The two terms are often confused and need to be clearly defined to identify which problem we are attempting to solve.
 ====
 
-Path finding and routing can be implemented in a number of different ways and multiple path-finding and routing algorithms can co-exist on the Lightning network, just as multiple path-finding and routing algorithms exist on the internet. Source-based path finding is one of many possible solutions and is successful at the current scale of the Lightning network.
+As we will see next, the Lightning Network currently uses a _source-based_ protocol for pathfinding and an _onion routed_ protocol for routing payments. Source-based means that the sender of the payment has to find a path through the network to the intended destination. Onion-routed means that the elements of the path are layered (like an onion), with each layer encrypted so that it can only be seen by one node at a time. We will discuss onion routing in the next section.
 
-The path finding strategy currently implemented by Lightning nodes is to "probe" paths until one is found that has enough liquidity to forward the payment. This is an iterative process of trial and error, until success is achieved or no path is found. The algorithm currently does not necessarily result in the path with the lowest fees. While this is not optimal and certainly can be improved, even this simplistic strategy works quite well.
+=== Source-based Pathfinding
+
+If we knew the exact channel balances of every channel we could easily compute a payment path using any of the standard pathfinding algorithms taught in any computer science program. This could even be solved in a way that optimizes the fees paid to nodes for forwarding the payment.
+
+However, the balance information of all channels is not and cannot be known to all participants of the network. We need more innovative pathfinding strategies.
+
+With only partial information about the network topology, pathfinding is a real challenge and active research is still being conducted into this part of the Lightning Network. The fact that the pathfinding problem is not "fully solved" in the Lightning Network is a major point of criticism towards the technology.
+
+[NOTE]
+====
+One common criticism of path-finding in the Lightning network is that it is unsolvable because it is equivalent to the NP-complete _Traveling Salesperson Problem_, a fundamental problem in computational complexity theory. In fact, pathfinding in Lightning is not equivalent to TSP and falls into a different class of problems. We successfully solve these types of problems (pathfinding in graphs with incomplete information) every time we ask Google to give us driving directions with traffic avoidance. We also successfully solve this problem every time we route a payment on the Lightning network.
+====
+
+Pathfinding and routing can be implemented in a number of different ways and multiple path-finding and routing algorithms can co-exist on the Lightning network, just as multiple path-finding and routing algorithms exist on the internet. Source-based pathfinding is one of many possible solutions and is successful at the current scale of the Lightning network.
+
+The pathfinding strategy currently implemented by Lightning nodes is to "probe" paths until one is found that has enough liquidity to forward the payment. This is an iterative process of trial and error, until success is achieved or no path is found. The algorithm currently does not necessarily result in the path with the lowest fees. While this is not optimal and certainly can be improved, even this simplistic strategy works quite well.
 
 This "probing" is done by the Lightning node or wallet and is not directly seen by the user.
 The user might only realize that probing is taking place if the payment does not complete instantly.
 
 [NOTE]
 ====
-On the Internet we use the internet protocol and an IP forwarding algorithm to forward internet packages from the sender to the destination. While these protocols have the nice property of allowing  internet hosts to collaboratively find a path for information flow through the internet, we cannot reuse and adopt this protocol for forwarding payments on the Lightning Network. Unlike the internet, Lightning payments have to be _atomic_ and channel balances have to remain _private_. Furthermore, the channel capacity in Lightning changes frequently, unlike the Internet where connection capacity is relatively static. These constraints require novel strategies.
+On the Internet we use the internet protocol and an IP forwarding algorithm to forward internet packages from the sender to the destination. While these protocols have the nice property of allowing internet hosts to collaboratively find a path for information flow through the internet, we cannot reuse and adopt this protocol for forwarding payments on the Lightning Network. Unlike the internet, Lightning payments have to be _atomic_ and channel balances have to remain _private_. Furthermore, the channel capacity in Lightning changes frequently, unlike the Internet where connection capacity is relatively static. These constraints require novel strategies.
 ====
 
-Of course, path finding is trivial if we want to pay our direct channel partner and we have enough balance on our side of the channel to do so. In all other cases, our node uses information from the gossip protocol to do path finding. This includes currently known public payment channels, known nodes, known topology (how known nodes are connected), known channel capacities, and known fee policies set by the node owners.
+Of course, pathfinding is trivial if we want to pay our direct channel partner and we have enough balance on our side of the channel to do so. In all other cases, our node uses information from the gossip protocol to do pathfinding. This includes currently known public payment channels, known nodes, known topology (how known nodes are connected), known channel capacities, and known fee policies set by the node owners.
 
 ==== Onion routing
 
@@ -540,7 +540,7 @@ A payment package used for routing is called an "onion". footnote:[The term "oni
 
 Let's use the onion analogy to follow a routed payment. On its route from payment sender (payer) to payment destination (payee) the onion is passed from node to node along the path. The sender constructs the entire onion, from the center out. First, the sender creates the payment information for the (final) recipient of the payment and encrypts it with a layer of encryption that only the recipient can decrypt. Then, the sender wraps that layer with instructions for the node in the path _immediately preceding the final recipient_ and encrypts with a layer that only that node can decrypt.
 
-The layers are built up with instructions working backwards until the entire path is encoded in layers. The sender then gives the complete onion to the first node in the path that can only read the outermost layer. Each node peels a layer, and finds instructions inside revealing the next node in the path and passes the onion on. As each node peels one layer, it can't read the rest of the onion. All it knows is where the onion came from and where it is going next, without any indication as to who is the original sender or the ultimate recipient.
+The layers are built up with instructions working backward until the entire path is encoded in layers. The sender then gives the complete onion to the first node in the path that can only read the outermost layer. Each node peels a layer, and finds instructions inside revealing the next node in the path and passes the onion on. As each node peels one layer, it can't read the rest of the onion. All it knows is where the onion came from and where it is going next, without any indication as to who is the original sender or the ultimate recipient.
 
 This continues until the onion reaches the payment destination (payee). Then, the destination node opens the onion and finds there are no further layers to decrypt and can read the payment information inside.
 
@@ -623,7 +623,7 @@ In contrast, Alice will not open a channel to someone unknown who just sent her 
 
 While the Lightning Network is built on top of Bitcoin and inherits many of its features and properties, there are important differences that users of both networks need to be aware of.
 
-Some of these differences are differences of terminology. There are also architectural differences and differences in the user experience. In the next few sections we will examine the differences and similarities, explain the terminology and adjust our expectations.
+Some of these differences are differences in terminology. There are also architectural differences and differences in the user experience. In the next few sections we will examine the differences and similarities, explain the terminology and adjust our expectations.
 
 ==== Addresses vs Invoices, Transactions vs Payments
 
@@ -643,7 +643,7 @@ In order to make a payment on the Bitcoin network, a sender needs to consume one
 If a user has multiple UTXOs, they (or rather their wallet) will need to select which UTXO(s) to send.
 For instance, a user making a payment of 1 BTC can use a single output with value 1 BTC, two outputs with value 0.25 BTC and 0.75 BTC, or four outputs with value 0.25 BTC each.
 
-On Lightning, payments do not require inputs to be consumed, Instead each payment results in an update of the channel balance, redistributing it between the two channel partners. The sender experiences this as "moving" channel balance from their end of a channel to the other end, to their channel partner. Lightning payments use a series of channels to route from sender to recipient. Each of these channels must have sufficient capacity to route the payment.
+On Lightning, payments do not require inputs to be consumed, Instead, each payment results in an update of the channel balance, redistributing it between the two channel partners. The sender experiences this as "moving" channel balance from their end of a channel to the other end, to their channel partner. Lightning payments use a series of channels to route from sender to recipient. Each of these channels must have sufficient capacity to route the payment.
 
 As many possible channels and paths can be used to make a payment, the Lightning user's choice of channels and paths is somewhat analogous to the Bitcoin user's choice of UTXO.
 
@@ -711,7 +711,7 @@ Hence, capacity and connectivity are critical and scarce resources in the Lightn
 ==== Incentives for Large Value Payment vs. Small Value Payments
 
 The fee structure in Bitcoin is independent of the transaction value.
-A $1 million transaction has the same fee as a $1 transaction on Bitcoin, assuming similar transaction size in bytes.
+A $1 million transaction has the same fee as a $1 transaction on Bitcoin, assuming a similar transaction size in bytes.
 In Lightning the fee is a fixed base fee plus a percentage of the transaction value.
 Therefore, in Lightning the payment fee increases with payment value.
 These opposing fee structures create different incentives and lead to different usage in regards to transaction value.
@@ -758,7 +758,7 @@ Both Bitcoin transactions and Lightning payments are irreversible and immutable.
 
 ==== Trust and counterparty risk
 
-Just as Bitcoin, Lightning requires the user only to trust mathematics, encryption, and that the software does not have any critical bugs. Neither Bitcoin nor Lightning require the user to trust a person, a company, an institution, or a government.
+Just as Bitcoin, Lightning requires the user only to trust mathematics, encryption, and that the software does not have any critical bugs. Neither Bitcoin nor Lightning requires the user to trust a person, a company, an institution, or a government.
 Since Lightning sits on top of Bitcoin and relies on Bitcoin as its underlying base layer, it is clear that the security model of Lightning reduces to the security of Bitcoin. This means that Lightning offers broadly the same security as Bitcoin under most circumstances, with only a slight reduction in security under some narrow circumstances.
 
 ==== Permissionless operation
@@ -772,6 +772,6 @@ Both, Bitcoin and Lightning are open-source software systems built by a decentra
 
 === Conclusion
 
-In this chapter we looked at how the Lightning network actually works and all of the constituent components. We examined each step in constructing, operating and closing a channel. We looked at how payments are routed. Finally we compared Lightning and Bitcoin and analyzed their differences and commonalities.
+In this chapter we looked at how the Lightning network actually works and all of the constituent components. We examined each step in constructing, operating and closing a channel. We looked at how payments are routed. Finally, we compared Lightning and Bitcoin and analyzed their differences and commonalities.
 
 In the next several chapters we will revisit all these topics, but in much more detail.


### PR DESCRIPTION
**Applied changes**:

***Chapter 1***
transaction -> transactions
faciliate -> facilitate
high speed -> high-speed
receieve -> receive
Megabyte -> Megabytes
Throughout this book -> Throughout this book,
In this chapter -> In this chapter,
In the next chapter -> In the next chapter,

***Chapter 2***
Also -> Also,
funds, -> funds
wallet -> the wallet
the technology -> technology
custody -> the custody
As third step -> As a third step
mentioned in the beginning -> mentioned at the beginning
Fortunately -> Fortunately,
crypto-currency -> cryptocurrency
In subsequent chapters -> In subsequent chapters,
real time -> real-time
open source -> open-source
clicks pay and -> clicks pay, and

***Chapter 3***
a payment -> payment
the  channels -> the channels
In that sense -> In that sense,
be build -> be built
However -> However,
which spends -> that spends
examine  in -> examine in
Initially -> Initially,
transaction  was -> transaction was
which pays -> that pays
the old -> old
requires -> require
protocl -> protocol
in channel -> in the channel
In this scenario -> In this scenario,
multiple channel -> multiple channels
meta data -> metadata
In the next few sections -> In the next few sections,
forward to -> forward it to
are  shared -> are shared
Path finding -> Pathfinding
reminded what -> reminded of what
allowing  internet -> allowing internet
backwards -> backward
successfuly -> successfully
differences of terminology -> differences in terminology
Instead -> Instead,
assuming similar -> assuming a similar
require -> requires
Finally -> Finally,