### PR TITLE
path-finding: rephrased sentence

### DIFF
--- a/path-finding.asciidoc
+++ b/path-finding.asciidoc
@@ -26,7 +26,7 @@ However, as discussed, the balance information of all channels cannot be availab
 Thus, we need to have one or more innovative path finding strategies.
 These strategies must relate closely to the routing algorithm that is used.
 As we will see in the next section, the Lightning Network uses a source-based onion-routing protocol for routing payments.
-This means in particular that the sender of the payment has to find a path through the network.
+In such a protocol it is the responsibility of the sender, i.e. payer, to find a path through the network.
 With only partial information about the network topology available this is a real challenge and active research is still being conducted into optimizing this part of the Lightning Network implementations.
 The fact that the path finding problem in the Lightning Network is not fully solved is a major point of criticism towards the technology.
 The path finding strategy currently implemented in Lightning nodes is to probe paths until one is found that has enough liquidity to forward the payment.


### PR DESCRIPTION
- this sentence already called out to me yesterday for change. As written it appears to be out of context leaving various interpretations of emphasis open. The reader might end up with "What is the author trying to say?" I think the emphasis is "it's the *sender's* job to compute the path". 
- If the sentence is taken out completely then the sentence before becomes hanging, so I decided to rephrase to give the sentence a single focus: the sender has to compute route. IMHO it reads better now and has a better flow of argument.