### PR TITLE
Glossary grammar/inconsistency fixes

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -37,7 +37,7 @@ AMP::
    Atomic Multipath Payments.
    A method for payments where the sender can use more than one of their channels to forward a payment.
    By default, a sender uses one channel to forward payment. 
-   This can cause issues, for example, where a sender has an two channels with an outgoing capacity of 0.5 BTC but wishes to forward a payment of 0.8 BTC.
+   This can cause issues, for example, where a sender has two channels with an outgoing capacity of 0.5 BTC but wishes to forward a payment of 0.8 BTC.
    By default, this payment would fail without rebalancing. 
    With AMP, the sender can split the payment between these channels and either have the entire payment succeed or fail, with no partial payment possible. 
 
@@ -74,8 +74,8 @@ bitcoin, Bitcoin::
 Bitcoin mining::
     Bitcoin mining is the process of constructing a block from recent Bitcoin transactions and then solving a computational problem required as Proof of Work.
     It is the process by which the shared bitcoin ledger (i.e. the bitcoin blockchain) is updated and by which new transactions are included in the ledger.
-    It is also the process by which new bitcoins are issued.
-    Every time a new block is created, the mining node will receive new bitcoins created within the coinbase transaction of that block.
+    It is also the process by which new bitcoin is issued.
+    Every time a new block is created, the mining node will receive new bitcoin created within the coinbase transaction of that block.
 
 block::
     A grouping of transactions, marked with a timestamp, and a fingerprint of the previous block. The block header is hashed to produce a proof of work, thereby validating the transactions. Valid blocks are added to the main blockchain by network consensus.
@@ -83,7 +83,7 @@ block::
 blockchain::
     The blockchain is an irreversible distributed database storing all Bitcoin transactions.
     The irreversibility comes from the fact that each group of transactions, referred to as a block, is validated by solving a Proof of Work riddle and including the hash of the previous block.
-    Thus the data can only be changed by an entity providing more than 51% of the computational power of the Bitcoin network.
+    Thus, the data can only be changed by an entity providing more than 51% of the computational power of the Bitcoin network.
     Blocks currently have a size limit of 1 MB.
     New blocks have a statistical probability of being produced every ten minutes.
 
@@ -196,7 +196,7 @@ funding transaction::
     The funding transaction is used to open a payment channel.
     From the perspective of the Bitcoin network, the process of opening a channel by creating a RSMC is started by creating the funding transaction and finished by broadcasting it to the Bitcoin network and have it included in the blockchain.
     The value of the funding transaction is exactly the capacity of the payment channel.
-    The output of the funding transaction is a 2-out-of-2 multisignature script (multisig) where each channel partner controls one key.
+    The output of the funding transaction is a 2-of-2 multisignature script (multisig) where each channel partner controls one key.
     It is supposed to be spent by the commitment transactions or by the closing transaction.
     Due to its multisig nature, it can only be spent mutually.
     It is part of the RSMC to ensure that either side of the channel can withdraw their funds without the necessity to trust the channel partner.
@@ -318,8 +318,8 @@ onion routing::
 
 output::
     The output of a Bitcoin transaction, also called an "Unspent Transaction Output" or "UTXO"
-    An output is essentially an amount of bitcoins that can be spent, as well as a script that defines what conditions need to be fulfilled for that bitcoin to be spent.
-    Every bitcoin transaction consumes the outputs of the sender and creates new outputs that can be spent later by the receiver.
+    An output is essentially an amount of bitcoin that can be spent, as well as a script that defines what conditions need to be fulfilled for that bitcoin to be spent.
+    Every Bitcoin transaction consumes the outputs of the sender and creates new outputs that can be spent later by the receiver.
     A typical bitcoin output will require the signature of the owner to be spent, but outputs can require the fulfillment of more complex scripts.
     For example, a multisignature script requires that two or more users to sign before an ouput can be spent, which is a fundamental building block of the Lightning Network.
 
@@ -347,7 +347,7 @@ payment::
     This payment hash is used by the Hashed Time Lock Contracts during the routing process.
 
 payment channel::
-    A payment channel is a financial relationship between two nodes on the Lightning Network, created using a multi-signature Bitcoin transaction.
+    A payment channel is a financial relationship between two nodes on the Lightning Network, created using a multisignature Bitcoin transaction.
     The channel partners can use the channel to send Bitcoin back and forth between each other without committing all of the transactions to the Bitcoin blockchain. 
     In a typical payment channel only two transactions, the funding transaction and the commitment transaction, are added to the blockchain.
     The other transactions are not included in the blockchain and are said to occur "off-chain".

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -190,14 +190,14 @@ Following is an alphabetically sorted list of all the GitHub contributors, inclu
 * Julien Wendling (@trigger67)
 * Kory Newton (@korynewton)
 * Luigi (@gin)
+* Omega X. Last (@omega_github_id)
 * Patrick Lemke (@PatrickLemke)
+* Paul Wackerow (@wackerow)
 * René Köhnke (@rene78)
 * Ricardo Marques (@RicardoM17)
 * Sergei Tikhomirov (@s-tikhomirov)
 * Simone Bovi (@SimoneBovi)
-* Omega X. Last (@omega_github_id)
 * Umar Bolatov (@bolatovumar)
-* Paul Wackerow (@wackerow)
 
 Without the help offered by everyone listed above, this book would not have been possible. Your contributions demonstrate the power of open source and open culture, and we are eternally grateful for your help.
 

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -197,6 +197,7 @@ Following is an alphabetically sorted list of all the GitHub contributors, inclu
 * Simone Bovi (@SimoneBovi)
 * Omega X. Last (@omega_github_id)
 * Umar Bolatov (@bolatovumar)
+* Paul Wackerow (@wackerow)
 
 Without the help offered by everyone listed above, this book would not have been possible. Your contributions demonstrate the power of open source and open culture, and we are eternally grateful for your help.
 


### PR DESCRIPTION
### glossary.asciidoc
Fixed plural `bitcoins`. Capitalized `Bitcoin transaction` and used `2-of-2` to be consistent with rest of book. Small grammatical error fixes. 