### PR TITLE
adds touch to /eclair/eclair.log so Wei doesn't fail

### DIFF
--- a/code/docker/eclair/logtail.sh
+++ b/code/docker/eclair/logtail.sh
@@ -2,4 +2,5 @@
 set -Eeuo pipefail
 
 # Show LND log from beginning and follow
+touch /eclair/eclair.log
 tail -n +1 -f /eclair/eclair.log || true


### PR DESCRIPTION
When the `docker-compose up` is run for the first time in the code/docker, the node for eclair wallet (Wei) fails, as it tries to `tail -f /eclair/eclair.log` which does not exist.

This is a quick fix of this problem that `touch /eclair.log` before trying to show the tail of it.