### PR TITLE
node_client.asciidoc typo

### DIFF
--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -862,7 +862,7 @@ We have OpenJDK 11.0.7 and Maven 3.6.1, so we're ready.
 The source code for Eclair is on Github. The +git clone+ command can create a local copy for us. Let's change to our home directory and run it there:
 
 ----
-$ cd
+$ cd ~
 $ git clone https://github.com/ACINQ/eclair.git
 
 ----


### PR DESCRIPTION
Sentence said "Let's change to our home directory", so we must do "cd ~", not just "cd".