### PR TITLE
node_client.asciidoc typo

### DIFF
--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -699,8 +699,8 @@ go version go1.13.4 linux/amd64
 We have 1.13.4, so we're ready to... Go! Next we need to tell any programs where to find the Go code. This is accomplished by setting the environment variable +GOPATH+. Usually the Go code is located in a directory named +gocode+ directly in the user's home directory. With the following two commands we consistently set the +GOPATH+ and make sure your shell adds it to your executable +PATH+. Note that the user's home directory is referred to as +~+ in the shell. 
 
 ----
-export GOPATH=~/gocode
-export PATH=$PATH:$GOPATH/bin
+$ export GOPATH=~/gocode
+$ export PATH=$PATH:$GOPATH/bin
 ----
 
 To avoid having to set these environment variables every time you open a shell, you can add those two lines to the end of your bash shell configuration file +.bashrc+ in your home directory, using the editor of your choice.


### PR DESCRIPTION
Shell commands start with "$"