### PR TITLE
node_client.asciidoc typo

### DIFF
--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -720,8 +720,8 @@ Once +go get+ finishes, you will have a sub-directory under +GOPATH+ that contai
 LND uses the +make+ build system. To build the project, we change directory to LND's source code and then use +make+ like this:
 
 ----
-cd $GOPATH/src/github.com/lightningnetwork/lnd
-make && make install
+$ cd $GOPATH/src/github.com/lightningnetwork/lnd
+$ make && make install
 ----
 
 After several minutes you will have two new commands +lnd+ and +lncli+ installed. Try them out and check their version to ensure they are installed:


### PR DESCRIPTION
Shell commands start with "$"