### PR TITLE
minor wording fixes

### DIFF
--- a/02_getting_started.asciidoc
+++ b/02_getting_started.asciidoc
@@ -247,7 +247,7 @@ Alice will see the transaction from the ATM in the "TRANSACTION HISTORY" tab of 
 
 [TIP]
 ====
-The number of "confirmations" on a transaction is the number of blocks mined since (and inclusive) the block that contained that transaction. Six confirmation is a best practice, but different Lightning wallets can consider a channel open after any number of confirmations. Some wallets even scale up the number of expected confirmations by the monetary value of the channel.
+The number of "confirmations" on a transaction is the number of blocks mined since (and inclusive of) the block that contained that transaction. Six confirmations is best practice, but different Lightning wallets can consider a channel open after any number of confirmations. Some wallets even scale up the number of expected confirmations by the monetary value of the channel.
 ====
 
 
@@ -398,7 +398,7 @@ Alice selects the option to "scan a payment request" and scans the QR code displ
 .Alice's Send Confirmation
 image:images/alice-send-detail.png[width=300]
 
-Alice presses "PAY," and a second later, Bob's tablet shows a successful payment. Alice has completed her first Lightning Network payment! It was fast, inexpensive, and easy. Now she can enjoy her latte which was purchased using a payment system that is fast, cheap and decentralized. And from now on, whenever Alice feels like drinking a coffee at Bob's Cafe she selects an item on Bob's tablet screen, scans the QR code with her cell phone, clicks pay, and is served a coffee, all within seconds and all without "on-chain" transaction.
+Alice presses "PAY," and a second later, Bob's tablet shows a successful payment. Alice has completed her first Lightning Network payment! It was fast, inexpensive, and easy. Now she can enjoy her latte which was purchased using a payment system that is fast, cheap and decentralized. And from now on, whenever Alice feels like drinking a coffee at Bob's Cafe she selects an item on Bob's tablet screen, scans the QR code with her cell phone, clicks pay, and is served a coffee, all within seconds and all without an "on-chain" transaction.
 
 
 === Conclusion


### PR DESCRIPTION
**changed:**

* 'mined since (and inclusive) the block' to 'mined since (and inclusive of) the block'
* 'Six confirmation is a best practice' to 'Six confirmations is best practice'
* 'without "on-chain" transaction' to 'without an "on-chain" transaction'