### PR TITLE
Update Eclair manual building instructions

### DIFF
--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -886,7 +886,7 @@ $ mvn package
 [INFO] eclair-node-gui                                                    [jar]
 [INFO]
 [INFO] --------------------< fr.acinq.eclair:eclair_2.13 >---------------------
-[INFO] Building eclair_2.13 0.4.1-SNAPSHOT                                [1/4]
+[INFO] Building eclair_2.13 0.4.3-SNAPSHOT                                [1/4]
 [INFO] --------------------------------[ pom ]---------------------------------
 
 [...]
@@ -899,12 +899,16 @@ $ mvn package
 [INFO] BUILD SUCCESS
 [INFO] ------------------------------------------------------------------------
 [INFO] Total time:  01:06 min
-[INFO] Finished at: 2020-06-26T09:43:21-04:00
+[INFO] Finished at: 2020-12-12T09:43:21-04:00
 [INFO] ------------------------------------------------------------------------
 
 ----
 
-After several minutes the build of the Eclair package will complete. You will find the Eclair server node under +eclair-node/target+, packaged as a zip file. Unzip and run it, by following the instructions found here:
+The build logs above contain "2.13", for building a commit around version 0.4.3, this is expected.
+
+After several minutes the build of the Eclair package should complete. But the "package" action will also run tests, and some of them connect to the internet, which could fail. If you want to skip tests, add +-DskipTests+ to the command.
+
+Now, unzip and run the built package, by following the instructions found here:
 
 https://github.com/ACINQ/eclair#installing-eclair
 


### PR DESCRIPTION
While building Eclair I encountered [a test failure](https://github.com/ACINQ/eclair/issues/1628). AFAIK, tests are not run for e.g. LND, so I think it would be reasonable to explain how to skip the tests, since the master of Eclair can apparently be ~~broken~~ (EDIT: it is not really broken, it is likely a weird DNS setup that causes the test to fail, but other users could be in the same situation), and it would suck for a reader who is just trying things out to be blocked on a flaky test failure.

I also added a sentence explaining that the "2.13" is not a version number, which is why I thought these build instructions were old, which they in fact were not ;)

To avoid confusing the reader, I changed the build timestamp to today, so that the version number of Eclair and the build date are not impossible, since it would look like a version of Eclair was being built before it had even been released.

Fixes #562 