### PR TITLE
fix(glossary): BOLT === Basis Of Lightning Technology NOT Basics

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -88,7 +88,7 @@ blockchain::
     New blocks have a statistical probability of being produced every ten minutes.
 
 BOLT::
-    BOLT, or Basis Of Lightning Technology, is the formal specification of the Lightning Network Protocol. It serves only as such without delving into implementation, unlike Bitcoin Improvement Proposals (BIPs), in which both are one and the same. It is available in https://github.com/lightningnetwork/lightning-rfc.
+    BOLT, or Basis Of Lightning Technology, is the formal specification of the Lightning Network Protocol. By following these standards, the various implementations are able to to work in conjucntion with one another to form the same network. It is available at https://github.com/lightningnetwork/lightning-rfc.
 
 Breach Remedy Transaction::
     A transaction claiming the outputs of a Revocable Sequence Maturity Contract with the help of the revocation key.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -88,7 +88,7 @@ blockchain::
     New blocks have a statistical probability of being produced every ten minutes.
 
 BOLT::
-    BOLT, or Basis Of Lightning Technology, is the formal specification of the Lightning Network Protocol. By following these standards, the various implementations are able to to work in conjucntion with one another to form the same network. It is available at https://github.com/lightningnetwork/lightning-rfc.
+    BOLT, or Basis of Lightning Technology, is the formal specification of the Lightning Network protocol. By following these standards, the various implementations are able to to work in conjucntion with one another to form the same network. It is available at https://github.com/lightningnetwork/lightning-rfc.
 
 Breach Remedy Transaction::
     A transaction claiming the outputs of a Revocable Sequence Maturity Contract with the help of the revocation key.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -88,7 +88,7 @@ blockchain::
     New blocks have a statistical probability of being produced every ten minutes.
 
 BOLT::
-    BOLT, or Basis of Lightning Technology, is the formal specification of the Lightning Network protocol. By following these standards, the various implementations are able to to work in conjucntion with one another to form the same network. It is available at https://github.com/lightningnetwork/lightning-rfc.
+    BOLT, or Basis of Lightning Technology, is the formal specification of the Lightning Network protocol. By following these standards, the various implementations are able to work in conjucntion with one another and form the same network. It is available at https://github.com/lightningnetwork/lightning-rfc.
 
 Breach Remedy Transaction::
     A transaction claiming the outputs of a Revocable Sequence Maturity Contract with the help of the revocation key.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -88,7 +88,7 @@ blockchain::
     New blocks have a statistical probability of being produced every ten minutes.
 
 BOLT::
-    BOLT, or Basis of Lightning Technology, is the formal specification of the Lightning Network protocol. By following these standards, the various implementations are able to work in conjucntion with one another and form the same network. It is available at https://github.com/lightningnetwork/lightning-rfc.
+    BOLT, or Basis Of Lightning Technology, is the formal specification of the Lightning Network protocol. Unlike Bitcoin, which has a reference implementation that also serves as the protocol's specification the various Lightning Network implementations follow BOLT so they can work with one another to form the same network. It is available at https://github.com/lightningnetwork/lightning-rfc.
 
 Breach Remedy Transaction::
     A transaction claiming the outputs of a Revocable Sequence Maturity Contract with the help of the revocation key.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -88,7 +88,7 @@ blockchain::
     New blocks have a statistical probability of being produced every ten minutes.
 
 BOLT::
-    BOLT, or Basics Of Lightning Technology, is the formal specification of the Lightning Network Protocol. It serves only as such without delving into implementation, unlike Bitcoin, in which both are one and the same. It is available in https://github.com/lightningnetwork/lightning-rfc.
+    BOLT, or Basis Of Lightning Technology, is the formal specification of the Lightning Network Protocol. It serves only as such without delving into implementation, unlike Bitcoin Improvement Proposals (BIPs), in which both are one and the same. It is available in https://github.com/lightningnetwork/lightning-rfc.
 
 Breach Remedy Transaction::
     A transaction claiming the outputs of a Revocable Sequence Maturity Contract with the help of the revocation key.


### PR DESCRIPTION
### Problem
- BOLT was defined as "**Basics** of Lightning Technology" which is incorrect

### Solution
- Change to "**Basis** Of Lightning Technology"

### Result
1. Correction to the BOLT acronym in the glossary
2. Simplify the definition