### PR TITLE
Consistency in spelling out the numbers that are < 10 (introduction)

### DIFF
--- a/01_introduction.asciidoc
+++ b/01_introduction.asciidoc
@@ -35,7 +35,7 @@ Assuming 250 Bytes on average per transaction this would result in a data stream
 This does not include the traffic overhead of forwarding the transaction information to other peers.
 While 10 MB/s does not seem extreme in the context of high-speed fibre and 5G mobile speeds, it would effectively exclude anyone who cannot meet this requirement from running a node, especially in countries where high-performance internet is not affordable or widely available.
 Users also have many other demands on their bandwidth and cannot be expected to expend this much only to receive transactions.
-Furthermore storing this information locally would result in 864,000 Megabytes per day. This is roughly 1 Terabyte of data or the size of a hard drive.
+Furthermore storing this information locally would result in 864,000 Megabytes per day. This is roughly one Terabyte of data or the size of a hard drive.
 While verifying 40,000 ECDSA signatures per second seems barely feasible (c.f.: https://bitcoin.stackexchange.com/questions/95339/how-many-bitcoin-transactions-can-be-verified-per-second) nodes could hardly catch up initial sync of the blockchain.
 ====
 
@@ -130,10 +130,10 @@ web designer::
 Saanvi is a web designer and developer in Bangalore, India. She accepts bitcoin for her work, but would prefer to get paid more frequently and so uses the Lightning Network to get paid incrementally for each small milestone she completes. With the Lightning Network, she can do more small jobs for more clients without worrying about fees or delays.
 
 content creator / curator::
-John is a 9-year-old boy from New Zealand, who wanted a games console just like his friends. However, his dad told him that in order to buy it, he had to earn the money himself. Now John is an aspiring artist, so he knows that while he is still improving, he can't charge much for his artwork.
+John is a nine-year-old boy from New Zealand, who wanted a games console just like his friends. However, his dad told him that in order to buy it, he had to earn the money himself. Now John is an aspiring artist, so he knows that while he is still improving, he can't charge much for his artwork.
 After learning about Bitcoin, he managed to set up a website to sell his drawings across the internet.
 By using the Lightning Network, John was able to charge as little as $1 for one of his drawings, which would normally be considered a micro-payment and, as such, would typically be impossible on traditional systems.
-Furthermore, most legacy financial systems wouldn't even allow a 9-year old like John to open an account!
+Furthermore, most legacy financial systems wouldn't even allow a nine-year old like John to open an account!
 By using a global currency such as bitcoin, John was able to sell his artwork to customers all over the world, store the money he's earned without a bank account and, in the end, buy the games console he so desperately wanted.
 
 gamer::


### PR DESCRIPTION
It would be fine to maintain consistency in spelling out the numbers (provided that they are not code/math/ BTC amounts) that are < 10. I left out "8 GB" unchanged, though. "eight Gigabyte" would perhaps be more consistent, but at the same time would seem very
unusual, whereas "eight GB" just make no sense to me.  
[A post about style](https://www.grammarly.com/blog/when-to-spell-out-numbers/) for the reference.
>In scientific and technical writing, the prevailing style is to write out numbers under ten. While there are exceptions to these rules, your predominant concern should be expressing numbers consistently.