### PR TITLE
Minor modification that removes ambiguity (ch. 3)

### DIFF
--- a/03_how_ln_works.asciidoc
+++ b/03_how_ln_works.asciidoc
@@ -377,8 +377,7 @@ You should consider a force close only as the last resort.
 A Protocol Breach is when your channel partner tries to cheat you, whether deliberately or not, by publishing an outdated commitment transaction to the Bitcoin blockchain, essentially initiating a (dishonest) force close from their side.
 
 Your node must be online and watching new blocks and transactions on the Bitcoin blockchain to detect this.
-Because your channel partner's payment will be encumbered by a timelock, your node has some time to act.
-You have until the time lock expires to detect a protocol breach and publish a _punishment transaction_.
+Because your channel partner's payment will be encumbered by a timelock, your node has some time to act until the time lock expires to detect a protocol breach and publish a _punishment transaction_.
 If you successfully detect the protocol breach and enforce the penalty, you will receive all of the funds in the channel, including your channel partner's funds.
 
 In this scenario, the channel closure will be rather fast.


### PR DESCRIPTION
I removed "You have". Now it's all in one sentence -- less ambiguous and more concise I believe. A more verbose alternative would be: 
>You have **time** until ...