### PR TITLE
Keeping fallback as one word for consistency.

### DIFF
--- a/03_how_ln_works.asciidoc
+++ b/03_how_ln_works.asciidoc
@@ -463,7 +463,7 @@ In case the sender's Lightning node is unable to send the payment over the Light
 
 [NOTE]
 ====
-While it is always possible to "fall back" to an on-chain Bitcoin transaction, it is actually better to open a new channel to the recipient instead. If you have to incur on-chain fees to make a payment, you might as well incur those fees to open a channel and make the payment over Lightning. After the payment is made, you are left with an open channel that has liquidity on the recipient's end and can be used to route payments back to your Lightning node in the future. One on-chain transaction gives you a payment and a channel for future use.
+While it is always possible to "fallback" to an on-chain Bitcoin transaction, it is actually better to open a new channel to the recipient instead. If you have to incur on-chain fees to make a payment, you might as well incur those fees to open a channel and make the payment over Lightning. After the payment is made, you are left with an open channel that has liquidity on the recipient's end and can be used to route payments back to your Lightning node in the future. One on-chain transaction gives you a payment and a channel for future use.
 ====
 
 


### PR DESCRIPTION
Keeping "fallback" as one word for consistency.