### PR TITLE
node_client.asciidoc: "collaboratively developed" instead of "collaborative developed"

### DIFF
--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -1,7 +1,7 @@
 [[set_up_a_lightning_node]]
 == Lightning Node Software
 
-As we have seen in previous chapters, a Lightning node is a computer system that participates in the Lightning Network. The Lightning Network is not a product or company, it is a set of open standards that define a baseline for interoperability. As such, Lightning node software has been built by a variety of companies and community groups. The vast majority of Lightning software is _open source_, meaning that the source code is open and licensed in such a way as to enable collaboration, sharing and community participation in the development process. Similarly, the Lightning node implementations we will present in this chapter are all open source and collaborative developed.
+As we have seen in previous chapters, a Lightning node is a computer system that participates in the Lightning Network. The Lightning Network is not a product or company, it is a set of open standards that define a baseline for interoperability. As such, Lightning node software has been built by a variety of companies and community groups. The vast majority of Lightning software is _open source_, meaning that the source code is open and licensed in such a way as to enable collaboration, sharing and community participation in the development process. Similarly, the Lightning node implementations we will present in this chapter are all open source and are collaboratively developed.
 
 Unlike Bitcoin, where the standard is defined by a _reference implementation_ in software (Bitcoin Core), in Lightning the standard is defined by a series of standards documents called _Basis of Lightning Technology (BOLT)_, found at the _lightning-rfc_ repository at:
 


### PR DESCRIPTION


[Collaborative](https://dictionary.cambridge.org/dictionary/english/collaborative) is not an adverb, [collaboratively](https://en.wiktionary.org/wiki/collaboratively) is. I also added 'are' for the sake of [parallelism](https://en.wikipedia.org/wiki/Parallelism_(grammar)), the said 'are' is optional, though.