### PR TITLE
node_operations.asciidoc: the blockchain size update

### DIFF
--- a/node_operations.asciidoc
+++ b/node_operations.asciidoc
@@ -86,9 +86,9 @@ At a minimum, the following will be required to run a Lightning Node:
 
 * **RAM**: a system with 2GB of RAM will _barely_ run both Bitcoin and Lightning nodes. It will perform much better with at least 4GB of RAM. The Initial Block Download will be especially challenging with less than 4GB of RAM. More than 8GB of RAM is unnecessary, because the CPU is the greater bottleneck for these types of services, due to cryptographic operations such as signature validation.
 
-* **Storage Drive**: this can be a Hard Drive or an Solid State Drive (SSD). An SSD will be significantly quicker for running a Bitcoin node. Most of the storage is used for the Bitcoin blockchain, which occupies more than 340GB (as of September 2020).
+* **Storage Drive**: this can be a Hard Drive or an Solid State Drive (SSD). An SSD will be significantly quicker for running a Bitcoin node. Most of the storage is used for the Bitcoin blockchain, which occupies more than 320GB (as of January 2021).
 
-* **Internet Connection**: a reliable internet connection will be required to download new Bitcoin blocks, as well as to communicate with other Lightning peers. During operation the estimated data use ranges from 10GB to 100GB per month, depending on configuration. At startup a Bitcoin full node downloads the full blockchain, 340GB as of September 2020.
+* **Internet Connection**: a reliable internet connection will be required to download new Bitcoin blocks, as well as to communicate with other Lightning peers. During operation the estimated data use ranges from 10GB to 100GB per month, depending on configuration. At startup a Bitcoin full node downloads the full blockchain, 324GB as of January 2021.
 
 * **Power Supply**: a reliable power supply is required as Lightning nodes need to be online at all times. A power failure will cause in-progress payments to fail. For heavy duty routing nodes, a backup or uninterruptible power supply (UPS) is useful in the case of power outages.
 Ideally, you should connect your Internet router to this UPS as well.
@@ -113,7 +113,7 @@ Traditional SATA-based SSDs are cheaper, but not as fast. SATA SSDs perform suff
 Smaller computers might not be able to take advantage of NVMe SSDs.
 For example, the Raspberry Pi 4 cannot benefit from them because of the limited bandwidth of its USB port.
 
-To choose the size, let's look at the Bitcoin blockchain. As of September 2020 its size is 340GB including the transaction index and grows by roughly 60GB/year. If you want to have some margin available for future growth or to install other data on your node, purchase at least a 512GB drive or better yet a 1TB drive.
+To choose the size, let's look at the Bitcoin blockchain. As of January 2021 its size is 324GB including the transaction index and grows by roughly 60GB/year. If you want to have some margin available for future growth or to install other data on your node, purchase at least a 512GB drive or better yet a 1TB drive.
 
 === Using an installer or helper
 


### PR DESCRIPTION
Based on [the data](https://ycharts.com/indicators/bitcoin_blockchain_size). I myself run a pruned node so I cannot verify it. The adduced data may not include the transaction index. Another source that is consistent with the size that I propose: https://www.blockchain.com/charts/blocks-size