### PR TITLE
node_operations.asciidoc: -m is needed for 'useradd' to work

### DIFF
--- a/node_operations.asciidoc
+++ b/node_operations.asciidoc
@@ -277,10 +277,10 @@ In addition, if you have connected an external drive, you will need to tell the 
 On most Linux systems you can create a new user with the +useradd+ command, like this:
 
 ----
-$ sudo useradd -d /external_drive/bitcoin -s /dev/null bitcoin
+$ sudo useradd -m -d /external_drive/bitcoin -s /dev/null bitcoin
 ----
 
-The +d+ flag assigns the user's home directory. In this case, we put it on the external drive. The +s+ flag assigns the user's interactive shell. In this case we set it to +/dev/null+ to disable interactive shell use. The last argument is the new user's username +bitcoin+.
+The +m+ and +d+ flags create the user's home directory as specified by /external_drive/bitcoin in this case. The +s+ flag assigns the user's interactive shell. In this case we set it to +/dev/null+ to disable interactive shell use. The last argument is the new user's username +bitcoin+.
 
 ==== Node startup
 


### PR DESCRIPTION
The reader was not asked to create a directory 'bitcoin' on his external drive. `sudo useradd -d /external_drive/bitcoin -s /dev/null bitcoin` will not make `/external_drive/bitcoin` the user's home directory as it can only assign existing directories. `sudo useradd -d /external_drive/bitcoin -s /dev/null bitcoin` cannot make new directories, for this '-m' is needed. Type `man useradd` for more or [read this](https://linuxize.com/post/how-to-create-users-in-linux-using-the-useradd-command/).