### PR TITLE
"also requires only ..." instead of "also only requires ..."

### DIFF
--- a/node_operations.asciidoc
+++ b/node_operations.asciidoc
@@ -386,7 +386,7 @@ rpcpassword=PASSWORD
 
 Even the +txindex+ option is not strictly necessary, though it will ensure your Bitcoin node creates an index of all transactions, which is required for some applications. The +txindex+ option is not required to run a Lightning node.
 
-A c-lightning Lightning node running on the same server also only requires a few lines in the configuration:
+A c-lightning Lightning node running on the same server also requires only a few lines in the configuration:
 
 ----
 network=mainnet


### PR DESCRIPTION
The first reads more natural to me. [Google Ngrams results](https://books.google.com/ngrams/graph?content=also+only+requires+a%2Calso+requires+only+a&year_start=1800&year_end=2019&corpus=26&smoothing=10&direct_url=t1%3B%2Calso%20only%20requires%20a%3B%2Cc0%3B.t1%3B%2Calso%20requires%20only%20a%3B%2Cc0) for the reference.