### PR TITLE
Removed -y flag in apt command

### DIFF
--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -840,7 +840,7 @@ The required Java compiler is part of OpenJDK 11. We will also need a build fram
 On a Debian/Ubuntu Linux system we can use the +apt+ command to install both OpenJDK11 and Maven as shown below:
 
 ----
-$ sudo apt install -y openjdk-11-jdk maven
+$ sudo apt install openjdk-11-jdk maven
 ----
 
 Verify that you have the correct version installed by running:


### PR DESCRIPTION
Someone could copy paste it and with the y flag it would automatically install. It’s Java on Ubuntu so it’s probably fine, but it’s a bad precedent to have commands that change so much in a users system without them explicitly approving. 

This is an opinion.