### PR TITLE
changed git clone to HTTPS

### DIFF
--- a/node_client.asciidoc
+++ b/node_client.asciidoc
@@ -44,7 +44,7 @@ To make a local copy of the repository on your computer, run the git command as 
 
 [git-clone-lnbook]
 ----
-$ git clone git@github.com:lnbook/lnbook.git
+$ git clone https://github.com/lnbook/lnbook.git
 ----
 
 You now have a complete copy of the book repository in a folder called +lnbook+. All subsequent examples will assume that you are running commands from that folder.


### PR DESCRIPTION
By using SSH on a fresh OS install you have to establish the public key of GitHub and if you don't have it you have to a song and dance about it. With HTTPS it works every time. Unless of course this is a security measure, in which case ignore this post.