### PR TITLE
Added script that fends and prints the versions

### DIFF
--- a/code/docker/check-versions.sh
+++ b/code/docker/check-versions.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# a small script to help sanity check the versions of the different node implementations
+dockerfiles=$(find . -name 'Dockerfile')
+# print location of dockerfiles
+echo $dockerfiles
+# print variables
+awk '/ENV/ && /VER|COMMIT/' $dockerfiles


### PR DESCRIPTION
Given the fast rate of change many users will be changing and experimenting with different versions of the nodes.

This is a small script to help an unfamiliar new user find and see the variables that affect the versioning.