### PR TITLE
Bump Bitcoin Core to latest version

### DIFF
--- a/code/docker/bitcoind/Dockerfile
+++ b/code/docker/bitcoind/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04 AS bitcoind-base
 RUN apt update && apt install -yqq \
 	curl gosu jq bash-completion
 
-ENV BITCOIND_VERSION 0.20.0
+ENV BITCOIND_VERSION 0.21.0
 # Install binaries for Bitcoin Core
 ADD https://bitcoincore.org/bin/bitcoin-core-${BITCOIND_VERSION}/bitcoin-${BITCOIND_VERSION}-x86_64-linux-gnu.tar.gz /usr/local
 RUN cd /usr/local/ \

--- a/code/docker/bitcoind/bitcoind-entrypoint.sh
+++ b/code/docker/bitcoind/bitcoind-entrypoint.sh
@@ -15,6 +15,7 @@ echo "Importing demo private key"
 echo "Bitcoin address: " ${address}
 echo "Private key: " ${privkey}
 echo "================================================"
+bitcoin-cli -datadir=/bitcoind createwallet regtest
 bitcoin-cli -datadir=/bitcoind importprivkey $privkey
 
 # Executing CMD


### PR DESCRIPTION
This latest version has signet so I think it will benefit lightning users since signet is a better testnet for lightning than testnet3.

New default wallet isn't created at start