### PR TITLE
Fix for issues #353 and #638. Missing terms added to glossary.

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -182,6 +182,9 @@ ephemeral key::
     This increases the security of transported messages or payments.
     Even if an ephemeral key leaks, only information about a single payment becomes public.
 
+fairness protocol::
+A way to achieve fair outcomes between participants, who do not need to trust each other, without the need for a central authority and it is the backbone of decentralized systems like Bitcoin.
+
 feature bits::
     A binary string that Lightning nodes use to communicate to each other which features they support.
     Feature bits are included in many types of communication, such as invoices or channel announcements.
@@ -201,6 +204,9 @@ funding transaction::
     It is supposed to be spent by the commitment transactions or by the closing transaction.
     Due to its multisig nature, it can only be spent mutually.
     It is part of the RSMC to ensure that either side of the channel can withdraw their funds without the necessity to trust the channel partner.
+
+game theory::
+The study of participants' behavior in strategic situations.
 
 globalfeatures::
     Globalfeatures of a Lightning Network node are the features of interest for all other nodes.
@@ -251,6 +257,9 @@ JIT Routing::
    An alternative to source-based routing first proposed by co-author René Pickhardt.
    With JIT routing, intermediary nodes along a path can pause an in-flight payment to rebalance their channels. 
    This might allow them to successfully forward payments that might otherwise have failed due to lack of outgoing capacity. 
+
+keysend::
+    A method of sending an unsolicited (without an invoice) payment.
 
 Lightning message::
    A Lightning message is an encrypted data string that can be sent between two peers on the Lightning Network. Similar to other communication protocols Lightning messages consist of a header and a body. The header and the body have their own HMAC. This ensures that the headers of fixed length will also be encrypted and adversaries won't be able to figure out what messages are being sent by inspecting the length.
@@ -440,6 +449,9 @@ secret key (aka private key)::
 ----
 5J76sF8L5jTtzE96r66Sf8cka9y44wdpJjMwCxR3tzLh3ibVPxh
 ----
+
+security primitive::
+Guarantees combined together in a certain order to ensure transaction fairness between multiple parties is the automatic outcome. These primitives are core to fairness protocols.
 
 Segregated Witness::
     Segregated Witness is an upgrade to the Bitcoin protocol, which technological innovation separates signature data from Bitcoin transactions. Segregated Witness was deployed as a soft fork; a change that technically makes Bitcoin’s protocol rules more restrictive.

--- a/routing.asciidoc
+++ b/routing.asciidoc
@@ -536,7 +536,7 @@ During processing each node will re-randomize the ephemeral key for the followin
 Luckily the ephemeral keys that Alice used for the ECDH with Dina can be derived from the ephemeral key that she used for Chan.
 Thus after Chan decrypts his layer he can use the shared secret and his ephemeral public key to derive the ephemeral public key that Dina is supposed to use and store it in the header of the Onion that he forwards to Dina.
 The exact process to generate the ephemeral keys for every hop will be explained at the very end of the chapter.
-Similarly it is important to recognize that Alice removed data from the end of Davids onion payload to create space for the per hop data in Chan's onion.
+Similarly it is important to recognize that Alice removed data from the end of Dina's onion payload to create space for the per hop data in Chan's onion.
 Thus when Chan has received his onion and removed his routing hints and per hop data the onion would be too short and he somehow needs to be able to append the 65 Bytes of filled junk data in a way that the HMACs will still be valid.
 This process of filler generation as well as the process of deriving the ephemeral keys is described in the end of this chapter.
 What is important to know is that every hop can derive the Ephemeral Public key that is necessary for the next hop and that the onions save space by always storing only one ephemeral key instead of all the keys for all the hops.


### PR DESCRIPTION
The final change to remove David from the text, and replacing with Dina. Fixes issues #353 and #638.