### PR TITLE
Update c-lightning docker version

### DIFF
--- a/code/docker/c-lightning/Dockerfile
+++ b/code/docker/c-lightning/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && apt install -yqq \
 	software-properties-common
 
 # c-lightning
-ENV C_LIGHTNING_VER 0.9.3~20210120202101201901~ubuntu20.04.1
+ENV C_LIGHTNING_VER 0.10.0~202104091415~ubuntu20.04.1
 RUN add-apt-repository -u ppa:lightningnetwork/ppa
 RUN apt-get install -yqq \
 	lightningd=${C_LIGHTNING_VER}


### PR DESCRIPTION
I got an error complaining the c-lightning version doesn't exist when trying out the example following chapter 4.
By updating to the latest version, I was able to get the example working.