### PR TITLE
Load wallet instead of creating a new one if it already existed

### DIFF
--- a/code/docker/bitcoind/bitcoind-entrypoint.sh
+++ b/code/docker/bitcoind/bitcoind-entrypoint.sh
@@ -15,7 +15,14 @@ echo "Importing demo private key"
 echo "Bitcoin address: " ${address}
 echo "Private key: " ${privkey}
 echo "================================================"
-bitcoin-cli -datadir=/bitcoind createwallet regtest
+
+if [ ! -d "/bitcoind/regtest/wallets/regtest" ] 
+then
+	bitcoin-cli -datadir=/bitcoind createwallet regtest
+else
+	bitcoin-cli -datadir=/bitcoind loadwallet regtest
+fi
+
 bitcoin-cli -datadir=/bitcoind importprivkey $privkey
 
 # Executing CMD


### PR DESCRIPTION
This allows us to reuse the existing bitcoind container by doing a `docker start -i bitcoind`.

Otherwise, we'd have to `docker rm bitcoind` and then `docker run` it every time when we stop the container.