### PR TITLE
Update 04_node_client.asciidoc

### DIFF
--- a/04_node_client.asciidoc
+++ b/04_node_client.asciidoc
@@ -220,7 +220,7 @@ Let us start by building and running the +bitcoind+ container. First, we use the
 [source,bash]
 ----
 $ cd code/docker
-$ docker build -t lnbook/bitcoind bitcoind
+$ sudo docker build -t lnbook/bitcoind bitcoind
 Sending build context to Docker daemon  12.29kB
 Step 1/25 : FROM ubuntu:20.04 AS bitcoind-base
  ---> c3c304cb4f22


### PR DESCRIPTION
added "sudo" to a command for building a bitcoind container.
I assume it is necessary for others because it was for me, otherwise got "permission denied" error.