### PR TITLE
Fix capitalization inconsistencies of Tor

### DIFF
--- a/routing.asciidoc
+++ b/routing.asciidoc
@@ -373,21 +373,21 @@ In the Lightning Network, we use a specific onion routing _packet_ format called
 
 [NOTE]
 ====
-While the Lightning Network also uses an onion routing scheme it is actually very different to the onion routing scheme that is used in the TOR network.
-Aside from the distinct cryptographic techniques they use, the biggest difference is that TOR is being used for arbitrary data to be exchanged between two participants where on the Lightning Network the main use case is to pay people and transfer data that encodes monetary value.
+While the Lightning Network also uses an onion routing scheme it is actually very different to the onion routing scheme that is used in the Tor network.
+Aside from the distinct cryptographic techniques they use, the biggest difference is that Tor is being used for arbitrary data to be exchanged between two participants where on the Lightning Network the main use case is to pay people and transfer data that encodes monetary value.
 In the Lightning Network, we're only concerned with transmitting the details that are needed for a successful payment.
 On the Lightning Network there is no analogy to the exit nodes of the Tor Network as there's no need to "exit" the network: all payments flow within the network.
 Although, in an idea model only a precise amount of information is leaked by a route, in practice several "side channels' exist, that may allow an adversary to deduce more information about a route.
 As an example, information about CTLV deltas, or the set of possible routes in the network may give away additional information about a given route.
 Similar to Tor, onion routing in the Lightning Network isn't secure against a global passive adversary (one that can monitor all links and information flows in the network).
 Today in the network, every node in the route sees the same payment hash, meaning that if two nodes are "compromised" more details of the route are leaked.
-On the TOR network nodes can theoretically be connected via a full graph as every node could create an encrypted connection with every other node on top of the Internet Protocol almost instantaneously and at no cost.
+On the Tor network nodes can theoretically be connected via a full graph as every node could create an encrypted connection with every other node on top of the Internet Protocol almost instantaneously and at no cost.
 On the Lightning Network payments can only flow along existing payment channels.
 Removing and adding of those channels is a slow and expensive process as it requires on-chain bitcoin transactions.
 On the Lightning Network nodes might not be able to forward a payment package because they do not own enough funds on their side of the payment channel.
-On the other hand there are hardly any plausible reasons other then its wish to act maliciously why a TOR node might not be able to forward an onion.
+On the other hand there are hardly any plausible reasons other then its wish to act maliciously why a Tor node might not be able to forward an onion.
 Last but not least the Lightning Network can actually run on Tor to use it as a message transport layer.
-This means that all connections of a node with its peers and the resulting communication will by obfuscated once more through the TOR network.
+This means that all connections of a node with its peers and the resulting communication will by obfuscated once more through the Tor network.
 ====
 
 Let's stick to our example in which Alice still wants to tip Dina and has decided to use the path via Bob and Chan.


### PR DESCRIPTION
Only the first letter of Tor is to be capitalized.  See: https://support.torproject.org/about/why-is-it-called-tor/