### PR TITLE
Update version of ubuntu package c-lightning Docker file

### DIFF
--- a/code/docker/c-lightning/Dockerfile
+++ b/code/docker/c-lightning/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && apt install -yqq \
 	software-properties-common
 
 # c-lightning
-ENV C_LIGHTNING_VER 0.9.3~20210120202101201901~ubuntu20.04.1
+ENV C_LIGHTNING_VER 0.10.0~202104091415~ubuntu20.04.1 
 RUN add-apt-repository -u ppa:lightningnetwork/ppa
 RUN apt-get install -yqq \
 	lightningd=${C_LIGHTNING_VER}


### PR DESCRIPTION
The older version is no longer available in the ppa repository and the docker container fails to build

`E: Version '0.9.3~20210120202101201901~ubuntu20.04.1' for 'lightningd' was not found
The command '/bin/sh -c apt-get install -yqq 	lightningd=${C_LIGHTNING_VER}' returned a non-zero code: 100`