### PR TITLE
Remove duplicated info about autopilot

### DIFF
--- a/05_node_operations.asciidoc
+++ b/05_node_operations.asciidoc
@@ -752,8 +752,6 @@ As a Lightning node operator, one of the recurring tasks you will need to perfor
 
 As soon as you get your Lightning node up and running, you can fund its Bitcoin wallet and then start opening channels with those funds.
 
-This task can be partially automated with the use of an _autopilot_, which is a software module that opens channels automatically based on some heuristic rules. Autopilot software is still in its infancy and it doesn't always select the best channel partners for you. It might be better, especially in the beginning, to open channels manually.
-
 You must choose channel partners carefully as your node's ability to send payments depends on who your channel partners are and how well connected they are to the rest of the Lightning Network. You also want to have more than one channel to avoid being susceptible to a single point of failure. Since Lightning now supports multi-path payments, you can split your initial funds into several channels and route bigger payments by combining their capacity. At the same time, avoid making your channels too small. Since you need to pay Bitcoin transaction fees to open and close a channel, the channel balance should not be so small that the on-chain fees consume a significant portion. It's all about balance!
 
 To summarize:


### PR DESCRIPTION
This PR removes a paragraph which describes autopilot, because a nearly-identical one appears a bit later in the chapter, in the **autopilot** section.

Both sections are virtually word-for-word the exact same.  It does not make sense to include the same content twice, and so close together.