### PR TITLE
Update c-lightning version

### DIFF
--- a/code/docker/c-lightning/Dockerfile
+++ b/code/docker/c-lightning/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && apt install -yqq \
 	software-properties-common
 
 # c-lightning
-ENV C_LIGHTNING_VER 0.9.3~20210120202101201901~ubuntu20.04.1
+ENV C_LIGHTNING_VER 0.10.0~202104091415~ubuntu20.04.1 
 RUN add-apt-repository -u ppa:lightningnetwork/ppa
 RUN apt-get install -yqq \
 	lightningd=${C_LIGHTNING_VER}


### PR DESCRIPTION
The c-lightning version mentioned in docker build
https://github.com/lnbook/lnbook/blob/e21944239ccc9cc01caa91c9591f71491765cd00/code/docker/c-lightning/Dockerfile#L8
has been updated in lightning/ppa https://launchpad.net/~lightningnetwork/+archive/ubuntu/ppa.

This causes build failure. 

Updated to `0.10.0~202104091415~ubuntu20.04.1 `.