### PR TITLE
Add HMAC to glossary

### DIFF
--- a/github_contributors.asciidoc
+++ b/github_contributors.asciidoc
@@ -19,6 +19,7 @@
 * Imran Lorgat (@ImranLorgat)
 * John Davies (@tigeryant)
 * Julien Wendling (@trigger67)
+* Jussi Tiira (@juhi24)
 * Kory Newton (@korynewton)
 * Lawrence Webber (@lwebbz)
 * Luigi (@gin)

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -221,6 +221,10 @@ hardware wallet::
 hash::
     A digital fingerprint of some binary input.
 
+hash-based message authentication code (HMAC)::
+    An HMAC is a message authentication code method for verifying the integrity and authenticity of a message based on a hash function and a shared secret.
+    It is used in onion routing to ensure the integrity of a packet at each hop.
+
 hash function::
     A cryptographic hash function is a mathematical algorithm that maps data of arbitrary size to a bit string of a fixed size (a hash) and is designed to be a one-way function, that is, a function which is infeasible to invert.
     The only way to recreate the input data from an ideal cryptographic hash function's output is to attempt a brute-force search of possible inputs to see if they produce a match, or use a rainbow table of matched hashes.


### PR DESCRIPTION
Added a glossary entry for HMAC since the abbreviation is used in another entry.