### PR TITLE
Typo and grammar fix in chapter 10

### DIFF
--- a/10_onion_routing.asciidoc
+++ b/10_onion_routing.asciidoc
@@ -531,7 +531,7 @@ Calculate the outer HMAC and stick it on the end of Bob's hop payload.
 
 ==== The final onion packet
 
-The final onion payload is read to send to Bob. Alice doesn't need to add any more hop payloads.
+The final onion payload is ready to be sent to Bob. Alice doesn't need to add any more hop payloads.
 
 Alice calculates an HMAC for the onion payload, to cryptographically secure it with a checksum that Bob can verify. Alice adds a 33-byte public session key that will be used by each hop to generate a shared-secret and the rho, mu, and pad keys. Finally Alice puts the onion version number (+0+ currently) in the front. This allows for future upgrades of the onion packet format.
 


### PR DESCRIPTION
Typo and grammatical fixes in paragraph 534, change "read to send" to "ready to be sent".