### PR TITLE
Typo in chapter 11

### DIFF
--- a/11_gossip_channel_graph.asciidoc
+++ b/11_gossip_channel_graph.asciidoc
@@ -355,7 +355,7 @@ bytes to encode the transaction index _within_ a block. This is more than enough
 
 Our final +scid+ format resembles:
 ----
-block_height (3 bytes) || transaction_index (3 bytes) || output_index (2 byes)
+block_height (3 bytes) || transaction_index (3 bytes) || output_index (2 bytes)
 ----
 
 Using bit packing techniques, we first encode the most significant 3 bytes as the block height, the next 3 bytes as the transaction index, and the least significant 2 bytes as the output index of that creates the channel UTXO.


### PR DESCRIPTION
Typo in line 358, change "byes" to "bytes".