### PR TITLE
Update glossary entry for address

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -31,7 +31,7 @@ Some additional definitions, to be cleaned up and moved into alphabetic order ar
 ////
 
 address::
-    A Bitcoin address looks like +1DSrfJdB2AnWaFNgSbv3MZC2m74996JafV+. It consists of a string of letters and numbers. It's really an encoded base58check version of a public key 160-bit hash. After P2SH, the 160-bit hash of a script is encoded, and with segwit the 256-bit hash of a script (or 160-bit key hash) is encoded. Just as you ask others to send an email to your email address, you would ask others to send you bitcoin to one of your Bitcoin addresses.
+    Bitcoin invoice addresses compactly encode the information necessary to pay a receiver. A modern address consists of a string of letters and numbers that starts with bc1 and looks like +bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4+. An address is shorthand for a receiver's locking script which can be used by a sender to sign over funds to the receiver. Most addresses either represent the receiver's public key or some form of redeemscript that defines more complex spending conditions. The above example is a bech32 address encoding a witness program locking funds to the hash of a public key (Pay to Witness Public Key Hash). There are also older address formats that start with 1 or 3 that use the base58check address encoding to represent public key hashes or script hashes.
 
 AMP::
    Atomic Multipath Payments is an extension to the protocol that allows triggering a spontaneous payment (no invoice required) that splits up a payment into multiple parts and uses additive secret sharing to ensure that the payment can only be pulled once all parts arrive. Additionally, each path of a AMP payment uses a distinct payment hash.


### PR DESCRIPTION
* Uses a bech32 address in the example
* Does not compare addresses with email addresses which suggests that addresses should be reused