### PR TITLE
Update bech32 glossary entry

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -58,7 +58,7 @@ balance::
     See _capacity_.
 
 bech32::
-    A checksummed base32 address format, at most 90 characters long, and capable of error correction. It is native to segregated witness (BIP173). Also referred to as "bc1" because of the current starting values of each address. Transactions made using bech32 are smaller in most cases, and therefore, may only require a lower fee.
+    Bech32 refers to a generic checksummed base32 encoded format featuring strong error detection guarantees. While bech32 was originally developed to be used as the address format for native segwit outputs (BIP173), it is also used to encode lightning invoices (BOLT11). While native segwit version 0 outputs (P2WPKH and P2WSH) use bech32, higher native segwit output versions (e.g. P2TR) use the improved variant bech32m (BIP350). Bech32(m) addresses are sometimes referred to as "bc1" for the prefix of such addresses. Native segwit outputs are more blockspace efficient than older output types and therefore may require lower fees to be spent.
 
 bip, BIP::
     Bitcoin Improvement Proposals. A set of proposals that members of the Bitcoin community have submitted to improve Bitcoin. For example, BIP-21 is a proposal to improve the Bitcoin uniform resource identifier (URI) scheme. BIPs can be found at https://github.com/bitcoin/bips.


### PR DESCRIPTION
* Properly distinguish between native segwit outputs and bech32 addresses
* Drop mention of the 90 character limit that is ignored by lightning invoices
* Mention that Lightning invoices use bech32
* Point out that higher version native segwit outputs use bech32m