### PR TITLE
Update glossary entry for block

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -73,7 +73,11 @@ Bitcoin mining::
     Every time a new block is created, the mining node will receive new bitcoin created within the coinbase transaction of that block.
 
 block::
-    A grouping of transactions, marked with a timestamp, and a fingerprint of the previous block. The block header is hashed to produce a proof of work, thereby validating the transactions. Valid blocks are added to the main blockchain by network consensus.
+    A block consist of a header and a body of valid transactions.
+    The block is marked with a timestamp and commits to a specific predecessor block.
+    When hashed, the block header provides the proof of work which makes the blockchain probabilistically immutable.
+    Blocks must adhere to the rules enforced by network consensus to extend the main blockchain.
+    When a block is appended to the blockchain, the included transactions are considered to have their first confirmation.
 
 blockchain::
     The blockchain is an irreversible distributed database storing all Bitcoin transactions.


### PR DESCRIPTION
Previous phrasing could be understood that proof of work makes transactions valid, but rather a block may only include valid transactions and confirms them.