### PR TITLE
Make AsciiDoc linguist-detectable 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.asciidoc linguist-detectable


### PR DESCRIPTION
Hi, bitcoinops recently merged [a similar PR][0], for that reason
I thought of submitting this change for your consideration.

This is githubcentrism, but the file's commited referencing
linguist, which is GitHub (I think), so once you migrate
out of GitHub, you would eventually find out if you still need
this file or not.

---

Before this change, project gets detected as:

Shell 32.9%
HTML 21.1%
Dockerfile 16.7%
Python 14.4%
Makefile 6.9%
XSLT 4.6%
CSS 3.4%

After this change, project gets detected as:

AsciiDoc 95.8%
Shell 1.4%
HTML 0.9%
Dockerfile 0.7%
Python 0.6%
Makefile 0.3%
Other 0.3%

This change was added for a cosmetic effect on GitHub.

---

Before this change | After this change
--- | ---
<img width="212" alt="Screen Shot 2021-09-29 at 23 12 02" src="https://user-images.githubusercontent.com/52637275/135349915-598b146a-3735-42da-917b-8c5eaa7fd26d.png"> | <img width="215" alt="Screen Shot 2021-09-29 at 23 12 08" src="https://user-images.githubusercontent.com/52637275/135349932-4ce44399-931d-4f3b-a460-c18cc031b276.png">

---

As you can see, with this change you'd be losing detail
on the weight of XSLT and CSS.
I suppose you should ponder if losing that detail the change is
still worth to you.
Cheers!

[0]: https://github.com/bitcoinops/bitcoinops.github.io/pull/653