### PR TITLE
Update 06_lightning_architecture - fix typos

### DIFF
--- a/06_lightning_architecture.asciidoc
+++ b/06_lightning_architecture.asciidoc
@@ -2,7 +2,7 @@
 
 In the first part of this book we introduced the main concepts of the Lightning Network, worked through a comprehensive example of routing a payment and setting up the tools we can use to explore further. In the second part of the book we will explore the Lightning Network in a lot more technical detail, dissecting each of the building blocks.
 
-In this section we will outline the components of the Lightning Network in more detail and provide a "big picture" perspective to guide you through the following chapters.
+In this section, we will outline the components of the Lightning Network in more detail and provide a "big picture" perspective to guide you through the following chapters.
 
 === The Lightning Network Protocol Suite
 
@@ -28,21 +28,21 @@ Payment Layer:: The highest layer of the network, which presents a reliable paym
 
 === Lightning in Detail
 
-Over the next 10 chapters, we will diseect the protocol suite and examine each component of the Lightning Network in detail.
+Over the next 10 chapters, we will dissect the protocol suite and examine each component of the Lightning Network in detail.
 
-We spent quite some time trying to decide the best order of presenting this detail. It's not an easy choice as there is so much interdependence between different components: as you start explaining one, you find that it pulls in quite a few of the other componenents. Instead of a top-down or bottom-up approach, we ended up choosing a more meandering path that starts with the most fundamental building blocks that are unique to the Lightning Network - Payment Channels - and moves outwards from there. But since that path is not obvious, we will use the Lightning Protocol Suite shown in <<lightning_network_protocol_suite>> as a map. In each chapter will focus on one or more related components, and you will see them highlighted in the protocol suite. Kind of like a map marker saying "You are here!".
+We spent quite some time trying to decide the best order of presenting this detail. It's not an easy choice as there is so much interdependence between different components: as you start explaining one, you find that it pulls in quite a few of the other components. Instead of a top-down or bottom-up approach, we ended up choosing a more meandering path that starts with the most fundamental building blocks that are unique to the Lightning Network - Payment Channels - and moves outwards from there. But since that path is not obvious, we will use the Lightning Protocol Suite shown in <<lightning_network_protocol_suite>> as a map. In each chapter will focus on one or more related components, and you will see them highlighted in the protocol suite. Kind of like a map marker saying, "You are here!".
 
 Here's what we will cover:
 
-<<payment_channels>>:: In this chapter we will look at how payment channels work, in significantly more depth than we saw in the earlier parts of the book. We will look at the structure and Bitcoin Script of the funding and commitment transactions and the process used by nodes to negotiate each step in the protocol.
+<<payment_channels>>:: In this chapter, we will look at how payment channels work, in significantly more depth than we saw in the earlier parts of the book. We will look at the structure and Bitcoin Script of the funding and commitment transactions and the process used by nodes to negotiate each step in the protocol.
 
-<<routing_htlcs>>:: Next, we will put together several payment channels in a network and route a payment from one end to the other. In that process we will dive into the Hash Time-Locked Contract smart contract and the Bitcoin Script that we use to construct it.
+<<routing_htlcs>>:: Next, we will put together several payment channels in a network and route a payment from one end to the other. In that process, we will dive into the Hash Time-Locked Contract smart contract and the Bitcoin Script that we use to construct it.
 
 <<channel_operation>>:: Putting together the concepts of a simple payment channel and a routed payment using HTLCs, we will now look at how HTLCs are part of each channel's commitment transaction. We will also look at the protocol for adding, settling, failing and removing HTLCs from the commitments.
 
 <<onion_routing>>:: Next, we will look at how the HTLC information is propagated across the network inside the onion routing protocol. We will look at the mechanism for layered encryption and decryption that gives the Lightning Network some of its privacy characteristics.
 
-<<gossip>>:: In this chapter we will look at how Lightning nodes find each other and learn about published channels, in order to construct a channel graph that they can use to find paths across the network.
+<<gossip>>:: In this chapter, we will look at how Lightning nodes find each other and learn about published channels, in order to construct a channel graph that they can use to find paths across the network.
 
 <<path_finding>>:: Next, we will see how the information from the gossip protocol is used by each node to build a "map" of the entire network, which it can use to find paths from one point to another to route payments. We'll also look at the exiting innovations in path finding such as multi-part payments.
 


### PR DESCRIPTION
Fix grammar at lines 5, 33, 37, 39, and 45. Fix typos at lines 31, 33.