### PR TITLE
Update 06_lightning_architecture - fix typos

### DIFF
--- a/06_lightning_architecture.asciidoc
+++ b/06_lightning_architecture.asciidoc
@@ -44,11 +44,11 @@ Here's what we will cover:
 
 <<gossip>>:: In this chapter we will look at how Lightning nodes find each other and learn about published channels, in order to construct a channel graph that they can use to find paths across the network.
 
-<<path_finding>>:: Next, we will see how the information from the gossip protocol is used by each node to build a "map" of the entire network, which it can use to find paths from one point to another to route payments. We'll also look at the exiting innovations in path finding such as multi-part payments.
+<<path_finding>>:: Next, we will see how the information from the gossip protocol is used by each node to build a "map" of the entire network, which it can use to find paths from one point to another to route payments. We'll also look at the exciting innovations in path finding, such as multi-part payments.
 
-<<payment_requests>>:: A key part of the Lightning Network are payment requests, also known as Lighting Invoices. In this chapter we dissect the structure and encoding of an invoice.
+<<payment_requests>>:: A key part of the Lightning Network are payment requests, also known as Lighting Invoices. In this chapter, we dissect the structure and encoding of an invoice.
 
-<<wire_protocol>>:: Underpinning the Lightning Network is the Peer-to-Peer protocol that nodes use to exchange messages about the network and about their channels. In this chapter we look at how those messages are constructed and the extension capabilities built into messages with feature bits and TLV encoding.
+<<wire_protocol>>:: Underpinning the Lightning Network is the Peer-to-Peer protocol that nodes use to exchange messages about the network and about their channels. In this chapter, we look at how those messages are constructed and the extension capabilities built into messages with feature bits and TLV encoding.
 
 <<encrypted_transport>>:: Moving down to the lower-level part of the network, we will look at the underlying encrypted transport system that ensures the secrecy and integrity of all communications between nodes.
 


### PR DESCRIPTION
Fix typo at line 47. Grammar fixes at lines 47, 49, and 51.