### PR TITLE
Update 03_how_ln_works.asciidoc

### DIFF
--- a/03_how_ln_works.asciidoc
+++ b/03_how_ln_works.asciidoc
@@ -730,7 +730,7 @@ Thus, no disputes can arise and it is unambiguous how much bitcoin is controlled
 On the Lightning Network, the balance in a channel at a particular time is known only to the two channel partners, and is only made visible to the rest of the network when the channel is closed.
 When the channel is closed, the final balance of the channel is submitted to the Bitcoin blockchain, and each partner receives their share of the bitcoin in that channel.
 For instance, if the opening balance was 1 BTC paid by Alice, and Alice made a payment of 0.3 BTC to Bob, then the final balance of the channel is 0.7 BTC for Alice and 0.3 BTC for Bob.
-If Alice tries to cheat by submitting the opening state of the channel to the Bitcoin blockchain, with 1 BTC for Alice and 0 BTC for Bob, then Bob can retaliate by submitting the true final state of the channel, as well as create a penalty transaction that gives him all the bitcoin in the channel.
+If Alice tries to cheat by submitting the opening state of the channel to the Bitcoin blockchain, with 1 BTC for Alice and 0 BTC for Bob, then Bob can retaliate by submitting a punishment transaction that gives him all the bitcoin in the channel.
 For the Lightning Network, the Bitcoin blockchain acts as a court system.
 Like a robotic judge, Bitcoin records the initial and final balances of each channel, and approves penalties if one of the parties tries to cheat.
 


### PR DESCRIPTION
I think Bob don't retaliates by sending the true commitment transaction (true state of the channel). If the cheat is discovered he is able to claim all the funds by executing a punishment transaction. Submitting the true state would be a double spend and would lead in the worst case to Bob getting less. I am not a big Lightning expert, though.