### PR TITLE
Remove reference to same heading.

### DIFF
--- a/05_node_operations.asciidoc
+++ b/05_node_operations.asciidoc
@@ -905,7 +905,7 @@ image::images/mtln_0504.png[]
 
 Circular rebalancing is supported by most Lightning node implementations and can be done on the command line or via one of the web management interfaces such as Ride The Lightning (see <<rtl>>).
 
-Channel rebalancing is a complex issue that is the subject of active research and covered in more detail in <<channel_rebalancing>>.(((range="endofrange", startref="ix_05_node_operations-asciidoc20")))(((range="endofrange", startref="ix_05_node_operations-asciidoc19")))
+Channel rebalancing is a complex issue that is the subject of active research.
 
 === Routing Fees
 


### PR DESCRIPTION
This sentence says channel rebalancing is covered in more detail somewhere, but the reference points to the current chapter.