### PR TITLE
fixing missing bitcoind local build commands

### DIFF
--- a/04_node_client.asciidoc
+++ b/04_node_client.asciidoc
@@ -167,7 +167,8 @@ Building the container locally will use a bit less of your network bandwidth, bu
 ----
 $ cd code/docker
 $ docker build -t lnbook/bitcoind bitcoind
-[+] Building 14.0s (24/24) FINISHED                                                                                                                                [...]
+[+] Building 14.0s (24/24) FINISHED                                                                                                                           
+[...]
  => => naming to docker.io/lnbook/bitcoind                                                                                                                         
 ----
 

--- a/04_node_client.asciidoc
+++ b/04_node_client.asciidoc
@@ -166,6 +166,15 @@ Building the container locally will use a bit less of your network bandwidth, bu
 [source,bash]
 ----
 $ cd code/docker
+$ docker build -t lnbook/bitcoind bitcoind
+[+] Building 14.0s (24/24) FINISHED                                                                                                                                [...]
+ => => naming to docker.io/lnbook/bitcoind                                                                                                                         
+----
+
+Our container is now built and ready to run. We can start bitcoind like this:
+
+[source,bash]
+----
 $ docker run -it --name bitcoind lnbook/bitcoind
 Starting bitcoind...
 Bitcoin Core starting


### PR DESCRIPTION
The paragraph above introduces the local build command, but it was missing in the original text.