### PR TITLE
Remove duplicated explanation of distinct session keys

### DIFF
--- a/10_onion_routing.asciidoc
+++ b/10_onion_routing.asciidoc
@@ -432,10 +432,6 @@ The onion size is 1,366 bytes, structured as shown in <<onion_packet>>:
 .The onion packet
 image::images/mtln_1015.png[]
 
-A unique trait of Sphinx as a mix-net packet format is that rather than include a distinct session key for each hop in the route, which would increase the size of the mix-net packet dramatically, instead a clever _blinding_ scheme is used to deterministically randomize the session key at each hop.
-
-In practice, this little trick allows us to keep the onion packet as compact as possible while still retaining the desired security properties.
-
 ==== Wrapping the Onion (Outlined)
 
 ((("onion routing","outline of wrapping process")))Here is the process of wrapping the onion, outlined next. Come back to this list as we explore each step with our real-world example.


### PR DESCRIPTION
This paragraph is repeated from a (more detailed) explanation just a few paragraphs up.