### PR TITLE
correction: short_channel_id definition

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -404,8 +404,8 @@ short channel ID (scid)::
     Once a channel is established, the index of the funding transaction on the blockchain is used as the short channel ID to uniquely identify the channel.
     The short channel ID consists of eight bytes referring to three numbers.
     In its serialized form, it depicts these three numbers as decimal values separated by the letter "x" (e.g., +600123x01x00+)
-    The first number (4 bytes) is the block height.
-    The second number (2 bytes) is the index of the funding transaction with the blocks.
+    The first number (3 bytes) is the block height.
+    The second number (3 bytes) is the index of the funding transaction with the blocks.
     The last number (2 bytes) is the transaction output.
 
 simplified payment verification (SPV)::


### PR DESCRIPTION
[BOLT 07(https://github.com/lightning/bolts/blob/master/07-routing-gossip.md)]:
The short_channel_id is the unique description of the funding transaction. It is constructed as follows:

    the most significant 3 bytes: indicating the block height
    the next 3 bytes: indicating the transaction index within the block
    the least significant 2 bytes: indicating the output index that pays to the channel.