### PR TITLE
Use 'unleashed' word

### DIFF
--- a/03_how_ln_works.asciidoc
+++ b/03_how_ln_works.asciidoc
@@ -650,7 +650,7 @@ With technologies such as atomic multipath payments (AMP) and multipart payments
 
 ((("Bitcoin–Lightning Network comparisons","change outputs")))To make a payment on the Bitcoin network, the sender needs to consume one or more unspent transaction outputs (UTXOs). UTXOs can only be spent in full; they cannot be divided and partially spent. So if a user wishes to spend 0.8 BTC, but only has a 1 BTC UTXO, they need to spend the entire 1 BTC UTXO by sending 0.8 BTC to the recipient and 0.2 BTC back to themselves as change. The 0.2 BTC change payment creates a new UTXO called a "change output."
 
-On Lightning, the funding transaction spends some Bitcoin UTXO, creating a multisignature UTXO to open the channel. Once the bitcoin is locked within that channel, portions of it can be sent back and forth within the channel, without the need to create any change.
+On Lightning, the funding transaction spends some Bitcoin UTXO, creating a multisignature UTXO to open the channel. Once the bitcoin is locked (or unleashed, rather) within that channel, portions of it can be sent back and forth within the channel, without the need to create any change.
 This is because the channel partners simply update the channel balance and only create a new UTXO when the channel is eventually closed using the channel closing transaction.
 
 ==== Mining Fees Versus Routing Fees

--- a/github_contributors.asciidoc
+++ b/github_contributors.asciidoc
@@ -1,5 +1,6 @@
 * 8go (@8go)
 * Aaqil Aziz (@batmanscode)
+* Abhishek Shandilya (@abhiShandy)
 * Alexander Gnip (@quantumcthulhu)
 * Alpha Q. Smith (@alpha_github_id)
 * Ben Skee (@benskee)


### PR DESCRIPTION
Reiterate that bitcoin is unleashed in lightning network instead of being locked