### PR TITLE
update link 'ln.bigsun.xyz' => 'ln.fiatjaf.com'

### DIFF
--- a/02_getting_started.asciidoc
+++ b/02_getting_started.asciidoc
@@ -28,7 +28,7 @@ Following is an inexhaustive list:
 * https://1ml.com[1ML Lightning explorer] 
 * https://explorer.acinq.co[ACINQ's Lightning explorer], with fancy visualization 
 * https://amboss.space[Amboss Space Lightning explorer], with community metrics and intuitive pass:[<span class="keep-together">visualizations</span>]
-* https://ln.fiatjaf.com/[Fiatjaf's Lightning explorer] with many diagrams
+* https://ln.fiatjaf.com[Fiatjaf's Lightning explorer] with many diagrams
 *  https://hashxp.org/lightning/node[hashXP Lightning explorer]
 
 [TIP]

--- a/02_getting_started.asciidoc
+++ b/02_getting_started.asciidoc
@@ -28,7 +28,7 @@ Following is an inexhaustive list:
 * https://1ml.com[1ML Lightning explorer] 
 * https://explorer.acinq.co[ACINQ's Lightning explorer], with fancy visualization 
 * https://amboss.space[Amboss Space Lightning explorer], with community metrics and intuitive pass:[<span class="keep-together">visualizations</span>]
-* https://ln.bigsun.xyz[Fiatjaf's Lightning explorer] with many diagrams
+* https://ln.fiatjaf.com/[Fiatjaf's Lightning explorer] with many diagrams
 *  https://hashxp.org/lightning/node[hashXP Lightning explorer]
 
 [TIP]


### PR DESCRIPTION
bigsun.xyz is abandoned and fiatjaf has moved to a new domain, [as his GitHub confirms](https://github.com/fiatjaf).