### PR TITLE
Update 15_payment_requests - sync default value with bolt

### DIFF
--- a/15_payment_requests.asciidoc
+++ b/15_payment_requests.asciidoc
@@ -190,7 +190,7 @@ A full list of all the currently defined tagged fields is given in <<table1503>>
 |`n`|`53`|The public key of the destination node.
 |`h`|`52`|A hash that represents a description of the payment itself. This can be used to commit to a description that's over 639 bytes in length.
 |`x`|Variable|The expiry time, in seconds, of the payment. The default is 1 hour (3,600) if not specified.
-|`c`|Variable|The `min_cltv_expiry` to use for the final hop in the route. The default is 9 if not specified.
+|`c`|Variable|The `min_final_cltv_expiry` to use for the final hop in the route. The default is 18 if not specified.
 |`f`|Variable|A fallback on-chain address to be used to complete the payment if the payment cannot be completed over the Lightning Network.
 |`r`|Variable|One or more entries that allow a receiver to give the sender additional ephemeral edges to complete the payment.
 |`9`|Variable|A set of 5-bit values that contain the feature bits that are required in order to complete the payment.


### PR DESCRIPTION
https://github.com/lightning/bolts/commit/c5693d336d5e166e8e5bfce45f081bc61c0e7999

bolts11 has changed `c`'s default `min_final_cltv_expiry`