### PR TITLE
Replace "length * 5 bytes" with "length * 5 bits"

### DIFF
--- a/15_payment_requests.asciidoc
+++ b/15_payment_requests.asciidoc
@@ -175,7 +175,7 @@ A given tag field is comprised of three components:
 
   * The `type` of the field (5 bits)
   * The `length` of the data of the field (10 bits)
-  * The `data` itself, which is `length * 5 bytes` in size
+  * The `data` itself, which is `length * 5 bits` in size
 
 A full list of all the currently defined tagged fields is given in <<table1503>>.
 


### PR DESCRIPTION
See BOLT 11.
https://github.com/lightning/bolts/blob/master/11-payment-encoding.md#tagged-fields