### PR TITLE
Add dependency of lightning nodes to bitcoind

### DIFF
--- a/code/docker/docker-compose.yml
+++ b/code/docker/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     expose:
       - "9735"
     restart: always
+    depends_on:
+      - bitcoind
 
   Bob:
     container_name: Bob
@@ -37,6 +39,8 @@ services:
     expose:
       - "9735"
     restart: always
+    depends_on:
+      - bitcoind
 
   Chan:
     container_name: Chan
@@ -48,6 +52,8 @@ services:
     expose:
       - "9735"
     restart: always
+    depends_on:
+      - bitcoind
 
   Dina:
     container_name: Dina
@@ -59,3 +65,5 @@ services:
     expose:
       - "9735"
     restart: always
+    depends_on:
+      - bitcoind


### PR DESCRIPTION
When starting all docker containers with `docker compose up`, there are errors from lightning nodes happening, particularly Alice where the start of the LND node results in an error of type `panic: Unable to synchronize wallet to chain`.
A solution is to make the lightning nodes depends on bitcoind to start up.