### PR TITLE
Fix IPv6 record type

### DIFF
--- a/11_gossip_channel_graph.asciidoc
+++ b/11_gossip_channel_graph.asciidoc
@@ -99,9 +99,9 @@ discovery using the DNS. Lightning's flavor of DNS-based bootstrapping uses up t
 
   * +SRV+ records for discovering a set of _node public keys_.
   * +A+ records for mapping a node's public key to its current +IPv4+ address.
-  * +AAA+ records for mapping a node's public key to its current +IPv6+ address.
+  * +AAAA+ records for mapping a node's public key to its current +IPv6+ address.
 
-Those somewhat familiar with the DNS protocol may already be familiar with the +A+ (name to IPv4 address) and +AAA+ (name to IPv6 address) record types, but not the +SRV+ type. The +SRV+ record type is used by protocols built on top of DNS to determine the _location_ for a specified service. In our context, the service in question is a given Lightning node, and the location is its IP address. We need to use this additional record type because, unlike nodes within the Bitcoin protocol, we need both a public key _and_ an IP address to connect to a node. As we see in <<wire_protocol>>, the transport encryption protocol used in the Lightning Network requires knowledge of the public key of a node before connecting, so as to implement identity hiding for nodes in the network.
+Those somewhat familiar with the DNS protocol may already be familiar with the +A+ (name to IPv4 address) and +AAAA+ (name to IPv6 address) record types, but not the +SRV+ type. The +SRV+ record type is used by protocols built on top of DNS to determine the _location_ for a specified service. In our context, the service in question is a given Lightning node, and the location is its IP address. We need to use this additional record type because, unlike nodes within the Bitcoin protocol, we need both a public key _and_ an IP address to connect to a node. As we see in <<wire_protocol>>, the transport encryption protocol used in the Lightning Network requires knowledge of the public key of a node before connecting, so as to implement identity hiding for nodes in the network.
 
 ===== A new peer's bootstrapping workflow
 


### PR DESCRIPTION
IPv6 uses AAAA: https://en.wikipedia.org/wiki/IPv6#IPv6_in_the_Domain_Name_System

BOLT: https://github.com/lightning/bolts/blob/master/10-dns-bootstrap.md#overview