### PR TITLE
Fix typo of reserved on chapter 10

### DIFF
--- a/10_onion_routing.asciidoc
+++ b/10_onion_routing.asciidoc
@@ -893,8 +893,8 @@ payments.
 the onion to encode information that tells each node _where_ and _how_ to
 forward the payment. Leveraging the TLV format, each piece of routing information
 (like the next node to which to pass the HTLC) is assigned a specific type (or key)
-encoded as a `BigSize` variable length integer (max sized as as 64-bit
-integer). These "essential" (reversed values below `65536`) types are defined
+encoded as a `BigSize` variable length integer (max sized as 64-bit
+integer). These "essential" (reserved values below `65536`) types are defined
 in BOLT #4, along with the rest of the onion routing details. Onion types with a
 value greater than `65536` are intended to be used by wallets and applications
 as "custom records."


### PR DESCRIPTION
From the following description of [BOLT1](https://github.com/lightning/bolts/blob/master/01-messaging.md#type-length-value-format)

> The type is encoded using the BigSize format. It functions as a message-specific, 64-bit identifier for the tlv_record determining how the contents of value should be decoded. type identifiers below 2^16 are reserved for use in this specification. 

I believe that `reversed` in the text is a typo for `reserved`.