### PR TITLE
Fix typo in funding_signed message type on Appendix C

### DIFF
--- a/appendix_protocol_messages.asciidoc
+++ b/appendix_protocol_messages.asciidoc
@@ -339,7 +339,7 @@ initiator only needs to send the funding outpoint of the channel.
 
 ((("funding_signed message")))((("wire protocol messages","funding_signed message")))To conclude, the responder sends the `funding_signed` message.
 
- * Type: 34
+ * Type: 35
  * Fields:
   ** `channel_id` : `channel_id`
   ** `sig` : `signature`


### PR DESCRIPTION
Definition of [BOLT#2](https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-funding_signed-message):

> 1. type: 35 (funding_signed)