### PR TITLE
HASH160 output fix - 08_routing_htlcs.asciidoc

### DIFF
--- a/08_routing_htlcs.asciidoc
+++ b/08_routing_htlcs.asciidoc
@@ -542,7 +542,7 @@ R = "Dinas secret"
 H256 = SHA256(R)
 H256 = 0575965b3b44be51e8057d551c4016d83cb1fba9ea8d6e986447ba33fe69f6b3
 H160 = RIPEMD160(H256)
-H160 = 9e017f6767971ed7cea17f98528d5f5c0ccb2c71
+H160 = 9c4890d47c6e410df4c274f5616b0ea9f7879c2f 
 ----
 
 Alice can calculate the RIPEMD160 hash of the payment hash that Dina provides and use the shorter hash in her HTLC, as can Bob and Chan!
@@ -557,7 +557,7 @@ OP_HASH160 <H160> OP_EQUALVERIFY
 Encoded in hex, this is:
 
 ----
-a9 9e017f6767971ed7cea17f98528d5f5c0ccb2c71 88
+a9 9c4890d47c6e410df4c274f5616b0ea9f7879c2f 88
 ----
 
 Where +OP_HASH160+ is +a9+ and +OP_EQUALVERIFY+ is +88+. This script is only 22 bytes long! We've saved 12 bytes from every transaction that redeems an HTLC on-chain.

--- a/10_onion_routing.asciidoc
+++ b/10_onion_routing.asciidoc
@@ -874,8 +874,8 @@ However, this means that the sender of the HTLC has to wait until expiry, and th
 [[keysend]]
 === Keysend Spontaneous Payments
 
-((("keysend spontaneous payments")))((("onion routing","keysend spontaneous payments")))In the payment flow described earlier in the chapter, we assumed that Dina
-received an invoice from Alice "out of band," or obtained it via some mechanism
+((("keysend spontaneous payments")))((("onion routing","keysend spontaneous payments")))In the payment flow described earlier in the chapter, we assumed that Alice
+received an invoice from Dina "out of band," or obtained it via some mechanism
 unrelated to the protocol (typically copy/paste or QR code scans). This trait
 means that the payment process always takes two steps: first, the sender
 obtains an invoice, and second, uses the payment hash (encoded in the invoice) to


### PR DESCRIPTION
Describe the error
In chapter "08_routing_htlcs.asciidoc", the output of one of the RIPEMD160 hash functions seems to be incorrect.

Snippet from chapter:
R = "Dinas secret"
H256 = SHA256(R)
H256 = 0575965b3b44be51e8057d551c4016d83cb1fba9ea8d6e986447ba33fe69f6b3 H160 = RIPEMD160(H256)
H160 = 9e017f6767971ed7cea17f98528d5f5c0ccb2c71

How to fix:
Given the H256 string, the H160 value should be 9c4890d47c6e410df4c274f5616b0ea9f7879c2f instead of 9e017f6767971ed7cea17f98528d5f5c0ccb2c71