### PR TITLE
Corrected error regarding Loop services and inbound

### DIFF
--- a/05_node_operations.asciidoc
+++ b/05_node_operations.asciidoc
@@ -855,7 +855,7 @@ There are three typical ways of getting inbound liquidity:
 
 * Ask someone to open a channel to your node. Offer to reciprocate, so that both of your nodes become better connected and balanced.
 
-* Use a submarine swap (e.g., Loop In) to exchange on-chain BTC for an inbound channel to your node.
+* Use a submarine swap (e.g., Loop-Out) to exchange your outbound liquidity for an on-chain payment back to your node. This will shift the liquidity of a channel from outbound to inbound.
 
 * Pay a third-party service to open a channel with you. Several such services exist. Some charge a fee to provide liquidity, some are free.
 

--- a/05_node_operations.asciidoc
+++ b/05_node_operations.asciidoc
@@ -855,7 +855,11 @@ There are three typical ways of getting inbound liquidity:
 
 * Ask someone to open a channel to your node. Offer to reciprocate, so that both of your nodes become better connected and balanced.
 
-* Use a submarine swap (e.g., Loop-Out) to exchange your outbound liquidity for an on-chain payment back to your node. This will shift the liquidity of a channel from outbound to inbound.
+* Use a submarine swap (e.g., Loop In) to increase the outbound liquidity of your node's channels by paying an on-chain payment to the Loop Service. 
+* Use a submarine swap (e.g., Loop-Out) to exchange your outbound liquidity to your node's on-chain wallet. This will shift the liquidity of a channel from outbound to inbound. 
+
+Loop-out is useful when you are receiving payments more than sending, and need to offload outbound liquidity. Loop-In is useful if you are sending payments and need to replenish outbound, but do
+not want to open a new channel. 
 
 * Pay a third-party service to open a channel with you. Several such services exist. Some charge a fee to provide liquidity, some are free.
 

--- a/05_node_operations.asciidoc
+++ b/05_node_operations.asciidoc
@@ -858,8 +858,7 @@ There are three typical ways of getting inbound liquidity:
 * Use a submarine swap (e.g., Loop In) to increase the outbound liquidity of your node's channels by paying an on-chain payment to the Loop Service. 
 * Use a submarine swap (e.g., Loop-Out) to exchange your outbound liquidity to your node's on-chain wallet. This will shift the liquidity of a channel from outbound to inbound. 
 
-Loop-out is useful when you are receiving payments more than sending, and need to offload outbound liquidity. Loop-In is useful if you are sending payments and need to replenish outbound, but do
-not want to open a new channel. 
+Loop-out is useful when you are receiving payments more than sending, and need to offload outbound liquidity. Loop-In is useful if you are sending payments and need to replenish outbound, but do not want to open a new channel. 
 
 * Pay a third-party service to open a channel with you. Several such services exist. Some charge a fee to provide liquidity, some are free.
 


### PR DESCRIPTION
Acquiring inbound liquidity is done through Loop-Out, not Loop-In. Loop-in is when you send the service on-chain bitcoin and then they pay you on lightning, thus increasing your outbound. Loop-out is when you pay on lightning (shifting liquidity from outbound to inbound) and receive funds back on-chain minus the service, etc. fees to increase inbound. The section is talking about how to acquire inbound, not outbound. The PR is meant to reflect the correct application of the topic.