### PR TITLE
fix: update_add_htlc capitalization

### DIFF
--- a/09_channel_operation.asciidoc
+++ b/09_channel_operation.asciidoc
@@ -54,12 +54,12 @@ image::images/mtln_0904.png["Alice and Bob's initial commitment transactions"]
 To add the HTLC, Alice starts the flow we saw in <<HTLC_commitment_message_flow>> by sending the +update_add_htlc+ message to Bob.
 
 [[update_add_htlc]]
-==== The update_add_HTLC Message
+==== The update_add_htlc Message
 
-((("hash time-locked contracts (HTLCs)","update_add_HTLC message")))((("update_add_HTLC message")))Alice sends the `update_add_HTLC` Lightning message to Bob. This message is defined in https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#adding-an-htlc-update_add_htlc[BOLT #2: Peer Protocol, `update_add_HTLC`], and is shown in Example 9-1. 
+((("hash time-locked contracts (HTLCs)","update_add_htlc message")))((("update_add_htlc message")))Alice sends the `update_add_htlc` Lightning message to Bob. This message is defined in https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#adding-an-htlc-update_add_htlc[BOLT #2: Peer Protocol, `update_add_htlc`], and is shown in Example 9-1. 
 
-[[update_add_HTLC_message_fields]]
-.The `update_add_HTLC` message
+[[update_add_htlc_message_fields]]
+.The `update_add_htlc` message
 ====
 ----
 [channel_id:channel_id]


### PR DESCRIPTION
Chapter 9. The "update_add_htlc" message has an improper capitalization "update_add_htlc". Multiple occurrences including in tags.