### PR TITLE
fix: dash separate block height and num of blocks

### DIFF
--- a/10_onion_routing.asciidoc
+++ b/10_onion_routing.asciidoc
@@ -204,7 +204,7 @@ outgoing_cltv_value: 700,038
 
 As you can see, the +amt_to_forward+ field is 50,100,000 millisatoshis, or 50,100 satoshis. That's because Chan expects a fee of 100 satoshis to route a payment to Dina. In order for Chan to "earn" that routing fee, Chan's incoming HTLC must be 100 satoshis more than Chan's outgoing HTLC. Since Chan's incoming HTLC is Bob's outgoing HTLC, the instructions to Bob reflect the fee Chan earns. In simple terms, Bob needs to be told to send 50,100 satoshi to Chan, so that Chan can send 50,000 satoshi and keep 100 satoshi.
 
-Similarly, Chan expects a timelock delta of 20 blocks. So Chan's incoming HTLC must expire 20 blocks _later_ than Chan's outgoing HTLC. To achieve this, Alice tells Bob to make his outgoing HTLC to Chan expire at block height 700,038-20 blocks later than Chan's HTLC to Dina.
+Similarly, Chan expects a timelock delta of 20 blocks. So Chan's incoming HTLC must expire 20 blocks _later_ than Chan's outgoing HTLC. To achieve this, Alice tells Bob to make his outgoing HTLC to Chan expire at block height 700,038 — 20 blocks later than Chan's HTLC to Dina.
 
 [TIP]
 ====


### PR DESCRIPTION
Chapter 10. A separator in a segmented sentence is a simple dash, making it confusing if it's a mathematical operation. Replacing with a long dash makes it clearer.