### PR TITLE
fix: capitalize Chan as firstname

### DIFF
--- a/10_onion_routing.asciidoc
+++ b/10_onion_routing.asciidoc
@@ -722,7 +722,7 @@ No one can tell the difference between filler put there by Alice and filler put 
 
 ==== Bob Constructs the New Onion Packet
 
-Bob now copies the onion payload into the onion packet, appends the outer HMAC for chan, re-randomizes the session key (the same way Alice the sender does) with the elliptic curve multiplication operation, and appends a fresh version byte.
+Bob now copies the onion payload into the onion packet, appends the outer HMAC for Chan, re-randomizes the session key (the same way Alice the sender does) with the elliptic curve multiplication operation, and appends a fresh version byte.
 
 To re-randomize the session key, Bob first computes the blinding factor for his hop, using his node public key and the shared secret he derived:
 ```


### PR DESCRIPTION
Chapter 10. "chan" is not capitalized properly.