### PR TITLE
fix: missing word "surface"

### DIFF
--- a/13_wire_protocol.asciidoc
+++ b/13_wire_protocol.asciidoc
@@ -160,7 +160,7 @@ implementation as well as the software that interacts with message parsing. A
 curious reader might ask, "why not just use Protobufs?" In response, the
 Lightning developers would respond that we're able to have the best of the
 extensibility of Protobufs while also having the benefit of a smaller
-implementation and thus smaller attack. As of version 3.15.6, the Protobuf
+implementation and thus smaller attack surface. As of version 3.15.6, the Protobuf
 compiler weighs in at over 656,671 lines of code.  In comparison, LND's
 implementation of the TLV message format weighs in at only 2.3k lines of code
 (including tests).


### PR DESCRIPTION
Chapter 13. The phrase seems to miss the word "surface". "attack surface" makes more sense considering the next sentence about the length of the source code.