### PR TITLE
Chapter 8, fix typo

### DIFF
--- a/08_routing_htlcs.asciidoc
+++ b/08_routing_htlcs.asciidoc
@@ -343,7 +343,7 @@ The use of a cryptographic hash function is one element that guarantees _trustle
 ((("Bitcoin script","HTLCs in")))((("hash time-locked contracts (HTLCs)","Bitcoin Script and")))In our gold coin example, Alice had a contract enforced by escrow like this:
 
 ____
-_Alice will reimburse Bob with 12 gold coins if you can show a valid message that hashes to:_ +0575...f6b3+. _Bob has 24 hours to show the secret after the contract was signed. If Bob does not provide the secret by this time, Alice's deposit will be refunded by the escrow service and the contract becomes invalid._
+_Alice will reimburse Bob with 12 gold coins if he can show a valid message that hashes to:_ +0575...f6b3+. _Bob has 24 hours to show the secret after the contract was signed. If Bob does not provide the secret by this time, Alice's deposit will be refunded by the escrow service and the contract becomes invalid._
 ____
 
 [role="pagebreak-before"]

--- a/github_contributors.asciidoc
+++ b/github_contributors.asciidoc
@@ -39,6 +39,7 @@
 * Sergei Tikhomirov (@s-tikhomirov)
 * Severin Alexander Bühler (@SeverinAlexB)
 * Simone Bovi (@SimoneBovi)
+* Shaurya Arora (@shaurya947)
 * Srijan Bhushan (@srijanb)
 * Taylor Masterson (@tjmasterson)
 * Umar Bolatov (@bolatovumar)


### PR DESCRIPTION
Fix typo in HTLC description: Bob should be referred to as "he" (3rd person) but is instead referred to as "you" (2nd person).