### PR TITLE
Fix path to bash completion files

### DIFF
--- a/code/docker/bitcoind/Dockerfile
+++ b/code/docker/bitcoind/Dockerfile
@@ -26,9 +26,9 @@ RUN cd /tmp && \
 # bash completion for bitcoind and bitcoin-cli
 ENV GH_URL https://raw.githubusercontent.com/bitcoin/bitcoin/master/
 ENV BC /usr/share/bash-completion/completions/
-ADD $GH_URL/contrib/bitcoin-cli.bash-completion $BC/bitcoin-cli
-ADD $GH_URL/contrib/bitcoind.bash-completion $BC/bitcoind
-ADD $GH_URL/contrib/bitcoin-tx.bash-completion $BC/bitcoin-tx
+ADD $GH_URL/contrib/completions/bash/bitcoin-cli.bash-completion $BC/bitcoin-cli
+ADD $GH_URL/contrib/completions/bash/bitcoind.bash-completion $BC/bitcoind
+ADD $GH_URL/contrib/completions/bash/bitcoin-tx.bash-completion $BC/bitcoin-tx
 
 # Copy bitcoind configuration directory
 COPY bitcoind /bitcoind


### PR DESCRIPTION
Figured the paths have changed to the bash completions so the docker build process failed.