### PR TITLE
Remove inactive Lightning explorer links (Fiatjaf, ACINQ)

### DIFF
--- a/02_getting_started.asciidoc
+++ b/02_getting_started.asciidoc
@@ -26,9 +26,7 @@ Users have the highest degree of control by running their own Bitcoin node and L
 Following is an inexhaustive list:
 
 * https://1ml.com[1ML Lightning explorer] 
-* https://explorer.acinq.co[ACINQ's Lightning explorer], with fancy visualization 
 * https://amboss.space[Amboss Space Lightning explorer], with community metrics and intuitive pass:[<span class="keep-together">visualizations</span>]
-* https://ln.bigsun.xyz[Fiatjaf's Lightning explorer] with many diagrams
 *  https://hashxp.org/lightning/node[hashXP Lightning explorer]
 
 [TIP]


### PR DESCRIPTION
Removed references to Fiatjaf’s and ACINQ’s Lightning explorers, as they are no longer active.